### PR TITLE
📌 pin moment to 2.18.1 bc. moment#4228

### DIFF
--- a/package.json
+++ b/package.json
@@ -30,7 +30,7 @@
     "bluebird": "^3.4.7",
     "bpmn-moddle": "^0.14.0",
     "debug": "^2.6.1",
-    "moment": "^2.18.1"
+    "moment": "2.18.1"
   },
   "devDependencies": {
     "@essential-projects/tslint-config": "^0.1.0",


### PR DESCRIPTION
Moment 2.19.0 doesn't play nice with webpack, so we pin it to 2.18.1. See https://github.com/moment/moment/issues/4228