### PR TITLE
Feature/versioning

### DIFF
--- a/ioc_module.js
+++ b/ioc_module.js
@@ -83,7 +83,7 @@ function registerInContainer(container) {
     .tags(entityDiscoveryTag);
 
   container.register('ProcessDefEntity', ProcessDefEntity)
-    .dependencies('ProcessDefEntityTypeService', 'ProcessRepository', 'FeatureService', 'MessageBusService', 'RoutingService', 'EventAggregator', 'TimingService', 'ProcessEngineService')
+    .dependencies('ProcessDefEntityTypeService', 'ProcessRepository', 'FeatureService', 'MessageBusService', 'RoutingService', 'EventAggregator', 'TimingService', 'ProcessEngineService', 'DatastoreService')
     .tags(entityDiscoveryTag);
 
   container.register('ProcessTokenEntity', ProcessTokenEntity)

--- a/package.json
+++ b/package.json
@@ -3,7 +3,7 @@
   "publishConfig": {
     "registry": "https://www.npmjs.com"
   },
-  "version": "0.2.0",
+  "version": "0.1.2",
   "description": "the core components for the process engine",
   "license": "MIT",
   "main": "dist/commonjs/index.js",

--- a/package.json
+++ b/package.json
@@ -3,7 +3,7 @@
   "publishConfig": {
     "registry": "https://www.npmjs.com"
   },
-  "version": "0.1.6",
+  "version": "0.2.0-alpha.feature-7dcf05bf",
   "description": "the core components for the process engine",
   "license": "MIT",
   "main": "dist/commonjs/index.js",
@@ -23,7 +23,7 @@
     "@essential-projects/messagebus_contracts": "^0.1.0",
     "@essential-projects/metadata": "^0.1.0",
     "@essential-projects/metadata_contracts": "^0.1.0",
-    "@process-engine/process_engine_contracts": "^0.1.0",
+    "@process-engine/process_engine_contracts": "^0.2.0-alpha.feature-3d0b4a64",
     "@essential-projects/routing_contracts": "^0.1.0",
     "@essential-projects/timing_contracts": "^0.1.0",
     "addict-ioc": "^2.2.8",

--- a/package.json
+++ b/package.json
@@ -3,7 +3,7 @@
   "publishConfig": {
     "registry": "https://www.npmjs.com"
   },
-  "version": "0.1.2",
+  "version": "0.2.0",
   "description": "the core components for the process engine",
   "license": "MIT",
   "main": "dist/commonjs/index.js",

--- a/src/entity_type_services/process_def.ts
+++ b/src/entity_type_services/process_def.ts
@@ -165,66 +165,69 @@ export class ProcessDefEntityTypeService implements IProcessDefEntityTypeService
   public async start(context: ExecutionContext, params: IParamStart, options?: IPublicGetOptions): Promise<IEntityReference> {
 
     const key: string = params ? params.key : undefined;
+    if (!key) {
+      return null;
+    }
+
     const version: string = params ? params.version : undefined;
-    if (key) {
-      const processDef: IEntityType<IProcessDefEntity> = await this.datastoreService.getEntityType<IProcessDefEntity>('ProcessDef');
-      let processDefEntity: IProcessDefEntity;
-      let queryObjectVersion: ICombinedQueryClause;
 
-      if (version) {
-        queryObjectVersion = {
-          operator: 'and',
-          queries: [
-            {
-              attribute: 'key',
-              operator: '=',
-              value: key,
-            },
-            {
-              attribute: 'version',
-              operator: '=',
-              value: version,
-            },
-          ],
-        };
-      } else {
-        queryObjectVersion = {
-          operator: 'and',
-          queries: [
-            {
-              attribute: 'key',
-              operator: '=',
-              value: key,
-            },
-            {
-              attribute: 'latest',
-              operator: '=',
-              value: true,
-            },
-          ],
-        };
-      }
+    const processDef: IEntityType<IProcessDefEntity> = await this.datastoreService.getEntityType<IProcessDefEntity>('ProcessDef');
+    let processDefEntity: IProcessDefEntity;
+    let queryObjectVersion: ICombinedQueryClause;
 
-      const queryParamsLatest: IPrivateQueryOptions = { query: queryObjectVersion };
-      processDefEntity = await processDef.findOne(context, queryParamsLatest);
+    if (version) {
+      queryObjectVersion = {
+        operator: 'and',
+        queries: [
+          {
+            attribute: 'key',
+            operator: '=',
+            value: key,
+          },
+          {
+            attribute: 'version',
+            operator: '=',
+            value: version,
+          },
+        ],
+      };
+    } else {
+      queryObjectVersion = {
+        operator: 'and',
+        queries: [
+          {
+            attribute: 'key',
+            operator: '=',
+            value: key,
+          },
+          {
+            attribute: 'latest',
+            operator: '=',
+            value: true,
+          },
+        ],
+      };
+    }
 
-      if (!processDefEntity) {
-        // no process def with flag latest is found, for backwards compability we only query with key
-        const queryObject: IQueryClause = {
-          attribute: 'key',
-          operator: '=',
-          value: key,
-        };
+    const queryParamsLatest: IPrivateQueryOptions = { query: queryObjectVersion };
+    processDefEntity = await processDef.findOne(context, queryParamsLatest);
 
-        const queryParams: IPrivateQueryOptions = { query: queryObject };
-        processDefEntity = await processDef.findOne(context, queryParams);
-      }
+    if (!processDefEntity) {
+      // no process def with flag latest is found, for backwards compability we only query with key
+      const queryObject: IQueryClause = {
+        attribute: 'key',
+        operator: '=',
+        value: key,
+      };
 
-      if (processDefEntity) {
-        const processEntityRef: IEntityReference = await this.invoker.invoke(processDefEntity, 'start', undefined, context, context, params, options);
+      const queryParams: IPrivateQueryOptions = { query: queryObject };
+      processDefEntity = await processDef.findOne(context, queryParams);
+    }
 
-        return processEntityRef;
-      }
+    if (processDefEntity) {
+      const processEntityRef: IEntityReference = await this.invoker.invoke(processDefEntity, 'start', undefined, context, context, params, options);
+
+      return processEntityRef;
     }
 
     return null;

--- a/src/entity_type_services/process_def.ts
+++ b/src/entity_type_services/process_def.ts
@@ -173,54 +173,43 @@ export class ProcessDefEntityTypeService implements IProcessDefEntityTypeService
 
     const processDef: IEntityType<IProcessDefEntity> = await this.datastoreService.getEntityType<IProcessDefEntity>('ProcessDef');
     let processDefEntity: IProcessDefEntity;
-    let queryObjectVersion: ICombinedQueryClause;
+    const queryObjectLatestVersion: ICombinedQueryClause = {
+      operator: 'and',
+      queries: [
+        {
+          attribute: 'key',
+          operator: '=',
+          value: key,
+        },
+      ],
+    };
 
     if (version) {
-      queryObjectVersion = {
-        operator: 'and',
-        queries: [
-          {
-            attribute: 'key',
-            operator: '=',
-            value: key,
-          },
-          {
-            attribute: 'version',
-            operator: '=',
-            value: version,
-          },
-        ],
-      };
+      queryObjectLatestVersion.queries.push({
+        attribute: 'version',
+        operator: '=',
+        value: version,
+      });
     } else {
-      queryObjectVersion = {
-        operator: 'and',
-        queries: [
-          {
-            attribute: 'key',
-            operator: '=',
-            value: key,
-          },
-          {
-            attribute: 'latest',
-            operator: '=',
-            value: true,
-          },
-        ],
-      };
+      queryObjectLatestVersion.queries.push({
+        attribute: 'latest',
+        operator: '=',
+        value: true,
+      });
     }
 
-    const queryParamsLatest: IPrivateQueryOptions = { query: queryObjectVersion };
+    const queryParamsLatest: IPrivateQueryOptions = { query: queryObjectLatestVersion };
     processDefEntity = await processDef.findOne(context, queryParamsLatest);
 
     if (!processDefEntity) {
       // no process def with flag latest is found, for backwards compability we only query with key
-      const queryObject: IQueryClause = {
+      const queryObjectKeyOnly: IQueryClause = {
         attribute: 'key',
         operator: '=',
         value: key,
       };
 
-      const queryParams: IPrivateQueryOptions = { query: queryObject };
+      const queryParams: IPrivateQueryOptions = { query: queryObjectKeyOnly };
       processDefEntity = await processDef.findOne(context, queryParams);
     }
 

--- a/src/entity_types/process_def.ts
+++ b/src/entity_types/process_def.ts
@@ -956,7 +956,7 @@ export class ProcessDefEntity extends Entity implements IProcessDefEntity {
   }
 
   public async getDraft(context: ExecutionContext): Promise<IProcessDefEntity> {
-    const queryObject: ICombinedQueryClause = {
+    const queryObjectDraft: ICombinedQueryClause = {
       operator: 'and',
       queries: [
         {
@@ -971,40 +971,30 @@ export class ProcessDefEntity extends Entity implements IProcessDefEntity {
         },
       ],
     };
-    const queryParams: IPrivateQueryOptions = { query: queryObject };
+    const queryParams: IPrivateQueryOptions = { query: queryObjectDraft };
     const processDef: IEntityType<IProcessDefEntity> = await this.datastoreService.getEntityType<IProcessDefEntity>('ProcessDef');
     let draftEntity: IProcessDefEntity = await processDef.findOne(context, queryParams);
 
-    if (!draftEntity) {
-      const processDefData: any = {
-        key: this.key,
-        defId: this.defId,
-        counter: 0,
-        draft: true,
-        name: this.name,
-        xml: this.xml,
-        internalName: this.internalName,
-        path: this.path,
-        category: this.category,
-        module: this.module,
-        readonly: this.readonly,
-        version: this.version,
-        latest: false,
-        extensions: this.extensions,
-        persist: this.persist,
-      };
-
-      draftEntity = await processDef.createEntity(context, processDefData);
-      await draftEntity.save(context);
-
-      await this.updateDefinitions(context);
+    if (draftEntity) {
+      return draftEntity;
     }
+
+    const processDefData: any = Object.assign(this, {
+      counter: 0,
+      draft: true,
+      latest: false,
+    });
+
+    draftEntity = await processDef.createEntity(context, processDefData);
+    await draftEntity.save(context);
+
+    await this.updateDefinitions(context);
 
     return draftEntity;
   }
 
   public async getLatest(context: ExecutionContext): Promise<IProcessDefEntity> {
-    const queryObject: ICombinedQueryClause = {
+    const queryObjectLatest: ICombinedQueryClause = {
       operator: 'and',
       queries: [
         {
@@ -1019,7 +1009,7 @@ export class ProcessDefEntity extends Entity implements IProcessDefEntity {
         },
       ],
     };
-    const queryParams: IPrivateQueryOptions = { query: queryObject };
+    const queryParams: IPrivateQueryOptions = { query: queryObjectLatest };
     const processDef: IEntityType<IProcessDefEntity> = await this.datastoreService.getEntityType<IProcessDefEntity>('ProcessDef');
     const latestEntity: IProcessDefEntity = await processDef.findOne(context, queryParams);
 
@@ -1032,7 +1022,7 @@ export class ProcessDefEntity extends Entity implements IProcessDefEntity {
 
     await this.save(context);
 
-    const queryObject: ICombinedQueryClause = {
+    const queryObjectLatest: ICombinedQueryClause = {
       operator: 'and',
       queries: [
         {
@@ -1052,7 +1042,7 @@ export class ProcessDefEntity extends Entity implements IProcessDefEntity {
         },
       ],
     };
-    const queryParams: IPrivateQueryOptions = { query: queryObject };
+    const queryParams: IPrivateQueryOptions = { query: queryObjectLatest };
     const processDef: IEntityType<IProcessDefEntity> = await this.datastoreService.getEntityType<IProcessDefEntity>('ProcessDef');
     const latestEntity: IProcessDefEntity = await processDef.findOne(context, queryParams);
 

--- a/src/entity_types/process_def.ts
+++ b/src/entity_types/process_def.ts
@@ -892,6 +892,8 @@ export class ProcessDefEntity extends Entity implements IProcessDefEntity {
         this.defId = 'Definition_1';
       }
       this.counter = 0;
+      this.draft = true;
+      this.latest = false;
       if (!this.xml) {
         this.xml = '<?xml version="1.0" encoding="UTF-8"?>' +
           '<bpmn:definitions xmlns:bpmn="http://www.omg.org/spec/BPMN/20100524/MODEL" xmlns:bpmndi="http://www.omg.org/spec/BPMN/20100524/DI" ' +
@@ -995,9 +997,34 @@ export class ProcessDefEntity extends Entity implements IProcessDefEntity {
 
       draftEntity = await processDef.createEntity(context, processDefData);
       await draftEntity.save(context);
+
+      await this.updateDefinitions(context);
     }
 
     return draftEntity;
+  }
+
+  public async getLatest(context: ExecutionContext): Promise<IProcessDefEntity> {
+    const queryObject: ICombinedQueryClause = {
+      operator: 'and',
+      queries: [
+        {
+          attribute: 'key',
+          operator: '=',
+          value: this.key,
+        },
+        {
+          attribute: 'latest',
+          operator: '=',
+          value: true,
+        },
+      ],
+    };
+    const queryParams: IPrivateQueryOptions = { query: queryObject };
+    const processDef: IEntityType<IProcessDefEntity> = await this.datastoreService.getEntityType<IProcessDefEntity>('ProcessDef');
+    const latestEntity: IProcessDefEntity = await processDef.findOne(context, queryParams);
+
+    return latestEntity;
   }
 
   public async publishDraft(context: ExecutionContext): Promise<IProcessDefEntity> {

--- a/src/entity_types/process_def.ts
+++ b/src/entity_types/process_def.ts
@@ -1015,9 +1015,14 @@ export class ProcessDefEntity extends Entity implements IProcessDefEntity {
           value: this.key,
         },
         {
-          attribute: 'draft',
+          attribute: 'latest',
           operator: '=',
           value: true,
+        },
+        {
+          attribute: 'id',
+          operator: '!=',
+          value: this.id,
         },
       ],
     };

--- a/src/entity_types/process_def.ts
+++ b/src/entity_types/process_def.ts
@@ -995,11 +995,23 @@ export class ProcessDefEntity extends Entity implements IProcessDefEntity {
       return draftEntity;
     }
 
-    const processDefData: any = Object.assign(this, {
+    const processDefData: any = {
+      key: this.key,
+      defId: this.defId,
       counter: 0,
       draft: true,
+      name: this.name,
+      xml: this.xml,
+      internalName: this.internalName,
+      path: this.path,
+      category: this.category,
+      module: this.module,
+      readonly: this.readonly,
+      version: this.version,
       latest: false,
-    });
+      extensions: this.extensions,
+      persist: this.persist,
+    };
 
     draftEntity = await processDef.createEntity(context, processDefData);
     await draftEntity.save(context);

--- a/src/entity_types/process_def.ts
+++ b/src/entity_types/process_def.ts
@@ -301,7 +301,8 @@ export class ProcessDefEntity extends Entity implements IProcessDefEntity {
       try {
         const adapterKey = this.featureService.getRoutingAdapterKeyByApplicationId(appInstanceId);
         const response: IDataMessage = <IDataMessage> (await this.routingService.request(appInstanceId, message, adapterKey));
-        const ref = new EntityReference(response.data.namespace, response.data.namespace, response.data.namespace);
+        const ref = new EntityReference(response.data.namespace, response.data.type, response.data.id);
+
         return ref;
       } catch (err) {
         debugErr(`can not start process on application '${appInstanceId}' (key '${this.key}', features: ${JSON.stringify(features)}), error: ${err.message}`);


### PR DESCRIPTION
## What did you change?

Adds versioning of bpmn process definitions. 
ATTENTION: this PR breaks the process manager ui and requires some changes in charon, skeleton and demo.

Starting a process via message bus or the entity type method "start" will always result in a query trying to find the "latest" processDef. If there is no "latest" ProcessDef present this method will try to find a ProcessDef by the given key.

## How can others test the changes?

- https://github.com/process-engine/process_engine_contracts/pull/2

Check out process_engine_meta (branch 'feature/demo-test')

```shell
meta git update
meta exec --include-only=process_engine_contracts "git checkout feature/versioning"
meta exec --include-only=process_engine "git checkout feature/versioning"
meta exec --include-only=demo "git checkout feature/versioning"

npm install

meta exec --exclude=demo "gulp build"
meta exec --include-only=demo "npm run build"

cd demo
npm start
```

Within the ProcessManager new version columns and a filter for versions should be present indicating the version the ProcessDef at hand (draft, latest or archived).
Within the BPMN-Studio after loading a ProcessDef should be buttons to edit a draft and publish a latest version.

## PR-Checklist

Please check the boxes in this list after submitting your PR:

- [x] You can merge this PR **right now** (if not, please prefix the title with "WIP: ")
- [x] I've tested **all** changes included in this PR.
- [x] I've also reviewed this PR myself before submitting (e.g. for scrambled letters, typos, etc.)
- [x] I've merged the `develop` branch into my branch before finishing this PR.
- [x] I've **not added any other changes** than the ones described above.
- [x] I've mentioned all **PRs, which relate to this one**
