### PR TITLE
change token handling of subprocess

### DIFF
--- a/src/entity_types/process.ts
+++ b/src/entity_types/process.ts
@@ -244,9 +244,12 @@ export class ProcessEntity extends Entity implements IProcessEntity {
       const callerId = this.callerId;
 
       const source = this;
+      const tokenData: any = processToken.data || {};
+      const currentToken: any = tokenData.current;
+
       const data = {
         action: 'proceed',
-        token: processToken.data,
+        token: currentToken,
       };
       const msg = this.messageBusService.createEntityMessage(data, source, context);
       const channel = '/processengine/node/' + callerId;

--- a/src/entity_types/subprocess_external.ts
+++ b/src/entity_types/subprocess_external.ts
@@ -41,7 +41,8 @@ export class SubprocessExternalEntity extends NodeInstanceEntity implements ISub
     }
 
     const processToken = this.processToken;
-    const tokenData = processToken.data || {};
+    const tokenData: any = processToken.data || {};
+    const currentToken: any = tokenData.current;
 
     // call sub process
     const nodeDef = this.nodeDef;
@@ -52,7 +53,7 @@ export class SubprocessExternalEntity extends NodeInstanceEntity implements ISub
         key: subProcessKey,
         source: this,
         isSubProcess: true,
-        initialToken: tokenData,
+        initialToken: currentToken,
       };
       const subProcessRef = await this.processDefEntityTypeService.start(internalContext, params);
       this.process.boundProcesses[subProcessRef.id] = subProcessRef;


### PR DESCRIPTION
Handling of process token in external subprocesses changed.

**Former behavior**
The complete token data including current and history is passed to the subprocess and the subprocess is returning its complete token data including history.

**Current behavior**
Only the current token of the parent process is passed to the subprocess. The subprocess returns only its last current token.
