### PR TITLE
fix _nodeHandlerMessagebus

### DIFF
--- a/src/entity_type_services/node_instance.ts
+++ b/src/entity_type_services/node_instance.ts
@@ -159,8 +159,9 @@ export class NodeInstanceEntityTypeService implements INodeInstanceEntityTypeSer
     const sourceRef = (msg && msg.source) ? msg.source : null;
     let source = null;
 
-    if (sourceRef) {
-
+    const canQuerySource: boolean = sourceRef && sourceRef._meta && sourceRef._meta.isNew === false;
+    
+    if (canQuerySource) {
       const entityType = await binding.datastoreService.getEntityType(sourceRef._meta.type);
       try {
         source = await entityType.getById(sourceRef.id, context);


### PR DESCRIPTION
## What did you change?

The callback _nodeHandlerMessagebus now takes into account, if the source is a persisted entity (entity reference) or not (marked as new).

## How others can test
start an app like skeleton, create a process model with property persist = false, start this process. In the previous there are entries in the log, that the entity couldn't be found as soon as the process ist started, with this fix they are gone.
This fix doesn't influence the behavior of the process engine, only an unnecessary query is filtered.

Related issue:
https://github.com/process-engine/process_engine/issues/25

Related PR:
https://github.com/essential-projects/messagebus/pull/5

## PR-Checklist

Please check the boxes in this list after submitting your PR:

- [x] You can merge this PR **right now** (if not, please prefix the title with "WIP: ")
- [x] I've tested **all** changes included in this PR.
- [x] I've also reviewed this PR myself before submitting (e.g. for scrambled letters, typos, etc.)
- [x] I've merged the `develop` branch into my branch before finishing this PR.
- [x] I've **not added any other changes** than the ones described above.
- [x] I've mentioned all **PRs, which relate to this one**
