### PR TITLE
Feature/execute process instance

### DIFF
--- a/src/process_engine_service.ts
+++ b/src/process_engine_service.ts
@@ -472,7 +472,7 @@ export class ProcessEngineService implements IProcessEngineService {
     return this._executeProcessRemotely(context, requiredFeatures, id, key, initialToken, version);
   }
 
-  public async executeProcessInstance(context: ExecutionContext, processInstanceId: string, initialToken: any): Promise<any> {
+  public async executeProcessInstance(context: ExecutionContext, processInstanceId: string, participantId: string, initialToken: any): Promise<any> {
     const processEntityType: IEntityType<IProcessEntity> = await this.datastoreService.getEntityType<IProcessEntity>('Process');
 
     const processInstance: IProcessEntity = await processEntityType.getById(processInstanceId, context);
@@ -484,10 +484,10 @@ export class ProcessEngineService implements IProcessEngineService {
                                 || this.featureService.hasFeatures(requiredFeatures);
 
     if (canStartProcessLocally) {
-      return this._executeProcessInstanceLocally(context, processInstance, initialToken);
+      return this._executeProcessInstanceLocally(context, processInstance, participantId, initialToken);
     }
 
-    return this._executeProcessInstanceRemotely(context, requiredFeatures, processInstanceId, initialToken);
+    return this._executeProcessInstanceRemotely(context, requiredFeatures, participantId, processInstanceId, initialToken);
   }
 
   public async createProcessInstance(context: ExecutionContext, processDefId: string, key: string, version?: string): Promise<string> {
@@ -540,7 +540,7 @@ export class ProcessEngineService implements IProcessEngineService {
     });
   }
 
-  private _executeProcessInstanceLocally(context: ExecutionContext, processInstance: IProcessEntity, initialToken: any): Promise<any> {
+  private _executeProcessInstanceLocally(context: ExecutionContext, processInstance: IProcessEntity, participantId: string, initialToken: any): Promise<any> {
     return new Promise(async(resolve: Function, reject: Function): Promise<void> => {
 
       const processInstanceChannel: string = `/processengine/process/${processInstance.id}`;
@@ -555,6 +555,7 @@ export class ProcessEngineService implements IProcessEngineService {
 
       await this.invoker.invoke(processInstance, 'start', undefined, context, context, {
         initialToken: initialToken,
+        participant: participantId,
       });
     });
   }

--- a/src/process_engine_service.ts
+++ b/src/process_engine_service.ts
@@ -487,7 +487,7 @@ export class ProcessEngineService implements IProcessEngineService {
       return this._executeProcessInstanceLocally(context, processInstance, participantId, initialToken);
     }
 
-    return this._executeProcessInstanceRemotely(context, requiredFeatures, participantId, processInstanceId, initialToken);
+    return this._executeProcessInstanceRemotely(context, requiredFeatures, processInstanceId, participantId, initialToken);
   }
 
   public async createProcessInstance(context: ExecutionContext, processDefId: string, key: string, version?: string): Promise<string> {
@@ -595,6 +595,7 @@ export class ProcessEngineService implements IProcessEngineService {
   private async _executeProcessInstanceRemotely(context: ExecutionContext,
                                        requiredFeatures: Array<IFeature>,
                                        processInstanceId: string,
+                                       participantId: string,
                                        initialToken: any): Promise<any> {
     const possibleRemoteTargets: Array<string> = this.featureService.getApplicationIdsByFeatures(requiredFeatures);
     if (possibleRemoteTargets.length === 0) {
@@ -610,6 +611,7 @@ export class ProcessEngineService implements IProcessEngineService {
       event: 'executeProcessInstance',
       processInstanceId: processInstanceId,
       initialToken: initialToken,
+      participantId: participantId,
     }, context);
 
     const targetApplicationChannel: string = `/processengine/${possibleRemoteTargets[0]}`;

--- a/src/process_engine_service.ts
+++ b/src/process_engine_service.ts
@@ -512,9 +512,11 @@ export class ProcessEngineService implements IProcessEngineService {
                                || this.featureService.hasFeatures(requiredFeatures);
 
     if (canStartProcessLocally) {
-      const processInstanceId: IProcessEntity = await processDefinition.createProcessInstance(context);
+      const processInstance: IProcessEntity = await processDefinition.createProcessInstance(context);
 
-      return processInstanceId.id;
+      await processInstance.save(context);
+
+      return processInstance.id;
     }
 
     return this._createProcessInstanceRemotely(context, requiredFeatures, processDefId, key, version);


### PR DESCRIPTION
## What did you change?

I added the two methods `` and `` as described in https://github.com/process-engine/process_engine/issues/28

Due to the current implementation of the direct creation and execution, I also implemented the remote scenario in my PR. I'm not sure whether or not that is an actual scenario.

I would rather not implement that behavior inside the process engine service and just expose an API to create and execute processes. The business logic needed to decide on which server to create or execute the process instance should not reside in this service, nor in this module.

## How can others test the changes?

When creating a process instance with the new method you get a process instance as a result. You should be able to execute that process instance with the second method.

If your test process contains a user task that is not rendered in the UI, but symbolized e.g. via a HTTP-Route, you should be able to find the user task by querying against the datastore using the given process instance `id`. You should also be able to proceed the test process with that process instance `id`.

## PR-Checklist

Please check the boxes in this list after submitting your PR:

- [x] You can merge this PR **right now** (if not, please prefix the title with "WIP: ")
- [x] I've tested **all** changes included in this PR.
- [x] I've also reviewed this PR myself before submitting (e.g. for scrambled letters, typos, etc.)
- [x] I've merged the `develop` branch into my branch before finishing this PR.
- [x] I've **not added any other changes** than the ones described above.
- [x] I've mentioned all **PRs, which relate to this one**
