### PR TITLE
Participant ID is nulled, when the lane has no role attached

### DIFF
--- a/src/entity_types/user_task.ts
+++ b/src/entity_types/user_task.ts
@@ -30,7 +30,7 @@ export class UserTaskEntity extends NodeInstanceEntity implements IUserTaskEntit
     const internalContext = await this.iamService.createInternalContext('processengine_system');
 
     const laneRole = await this.getLaneRole(internalContext);
-    if (!context.hasRole(laneRole)) {
+    if (laneRole !== null && !context.hasRole(laneRole)) {
       this.participant = null;
     }
 


### PR DESCRIPTION
## What did you change?

This fixes issue https://github.com/process-engine/process_engine/issues/34

## How can others test the changes?

Start a process with a lane where no role is attached. There should be an appropriate message on the participant channel.

## PR-Checklist

Please check the boxes in this list after submitting your PR:

- [x] You can merge this PR **right now** (if not, please prefix the title with "WIP: ")
- [x] I've tested **all** changes included in this PR.
- [x] I've also reviewed this PR myself before submitting (e.g. for scrambled letters, typos, etc.)
- [x] I've merged the `develop` branch into my branch before finishing this PR.
- [x] I've **not added any other changes** than the ones described above.
- [x] I've mentioned all **PRs, which relate to this one**
