### PR TITLE
Process token growths too much, when user task is executed

### DIFF
--- a/src/entity_types/user_task.ts
+++ b/src/entity_types/user_task.ts
@@ -66,7 +66,9 @@ export class UserTaskEntity extends NodeInstanceEntity implements IUserTaskEntit
     let uiConfig;
 
     const processToken = pojo.processToken;
-    const token = processToken.data || {};
+    const token = {
+      current: processToken.data.current,
+    };
     let uiData = token;
 
     const nodeDef = this.nodeDef;

--- a/src/entity_types/user_task.ts
+++ b/src/entity_types/user_task.ts
@@ -64,12 +64,12 @@ export class UserTaskEntity extends NodeInstanceEntity implements IUserTaskEntit
     const pojo = await this.toPojo(internalContext, {maxDepth: 1});
     let uiName;
     let uiConfig;
+    let uiData;
 
     const processToken = pojo.processToken;
     const token = {
       current: processToken.data.current,
     };
-    let uiData = token;
 
     const nodeDef = this.nodeDef;
     const extensions = nodeDef.extensions || null;
@@ -83,10 +83,15 @@ export class UserTaskEntity extends NodeInstanceEntity implements IUserTaskEntit
           uiConfig = this.parseExtensionProperty(prop.value, token, context);
         }
         if (prop.name === 'uiData') {
-          uiData = this.parseExtensionProperty(prop.value, token, context);
+          parsedToken = this.parseExtensionProperty(prop.value, token, context);
+          // Force current only to be in uiData
+          uiData = {
+            current: parsedToken.current,
+          };
         }
       });
     }
+    uiData = uiData || { current: token.current };
 
     const userTaskMessageData: IUserTaskMessageData = {
       userTaskEntity: pojo,

--- a/src/entity_types/user_task.ts
+++ b/src/entity_types/user_task.ts
@@ -83,7 +83,7 @@ export class UserTaskEntity extends NodeInstanceEntity implements IUserTaskEntit
           uiConfig = this.parseExtensionProperty(prop.value, token, context);
         }
         if (prop.name === 'uiData') {
-          parsedToken = this.parseExtensionProperty(prop.value, token, context);
+          const parsedToken = this.parseExtensionProperty(prop.value, token, context);
           // Force current only to be in uiData
           uiData = {
             current: parsedToken.current,


### PR DESCRIPTION
## What did you change?

This fixes issue https://github.com/process-engine/process_engine/issues/37. See description there.

## How can others test the changes?

Execute a process containing user tasks and inspect much lower memory footprint.

## PR-Checklist

Please check the boxes in this list after submitting your PR:

- [x] You can merge this PR **right now** (if not, please prefix the title with "WIP: ")
- [x] I've tested **all** changes included in this PR.
- [x] I've also reviewed this PR myself before submitting (e.g. for scrambled letters, typos, etc.)
- [x] I've merged the `develop` branch into my branch before finishing this PR.
- [x] I've **not added any other changes** than the ones described above.
- [x] I've mentioned all **PRs, which relate to this one**
