### PR TITLE
Feature/make draft optional

### DIFF
--- a/src/entity_type_services/process_def.ts
+++ b/src/entity_type_services/process_def.ts
@@ -114,8 +114,7 @@ export class ProcessDefEntityTypeService implements IProcessDefEntityTypeService
           key: process.id,
           defId: bpmnDiagram.definitions.id,
           counter: 0,
-          latest: false,
-          draft: true,
+          latest: true,
         };
 
         processDefEntity = await processDef.createEntity(context, processDefData);
@@ -141,8 +140,8 @@ export class ProcessDefEntityTypeService implements IProcessDefEntityTypeService
       processDefEntity.counter = processDefEntity.counter + 1;
 
       await this.invoker.invoke(processDefEntity, 'updateDefinitions', undefined, context, context, { bpmnDiagram: bpmnDiagram });
-      await processDefEntity.save(context, {isNew: false });
-      await processDefEntity.publishDraft(context);
+      await processDefEntity.save(context);
+      await processDefEntity.updateDefinitions(context);
     }
   }
 

--- a/src/entity_type_services/process_def.ts
+++ b/src/entity_type_services/process_def.ts
@@ -114,6 +114,7 @@ export class ProcessDefEntityTypeService implements IProcessDefEntityTypeService
           key: process.id,
           defId: bpmnDiagram.definitions.id,
           counter: 0,
+          draft: true,
           latest: true,
         };
 
@@ -140,8 +141,7 @@ export class ProcessDefEntityTypeService implements IProcessDefEntityTypeService
       processDefEntity.counter = processDefEntity.counter + 1;
 
       await this.invoker.invoke(processDefEntity, 'updateDefinitions', undefined, context, context, { bpmnDiagram: bpmnDiagram });
-      await processDefEntity.save(context);
-      await processDefEntity.updateDefinitions(context);
+      await processDefEntity.save(context, {isNew: false});
     }
   }
 

--- a/src/entity_types/process_def.ts
+++ b/src/entity_types/process_def.ts
@@ -325,18 +325,15 @@ export class ProcessDefEntity extends Entity implements IProcessDefEntity {
   }
 
   public async updateBpmn(context: ExecutionContext, xml: string): Promise<any> {
-
-    if (!this.draft) {
-      throw new Error('Process definition is not a draft!');
+    if (!xml) {
+      return null;
     }
 
-    if (xml) {
-      this.xml = xml;
-      this.counter = this.counter + 1;
-      await this.updateDefinitions(context);
+    this.xml = xml;
+    this.counter = this.counter + 1;
+    await this.updateDefinitions(context);
 
-      return { result: true };
-    }
+    return { result: true };
   }
 
   private _parseTimerDefinitionType(eventDefinition: any): TimerDefinitionType {


### PR DESCRIPTION
## What did you change?

- I made the updateBpmn-method not care if the process is a draft or not
- I made the import-method that imports processes from the processRepository import them as draft AND latest in the same record, instead of importing them twice
- Because of the above change, newly imported processes from the processRepository don't get "published" anymore

## How can others test the changes?

When starting the skeleton with this fix, you'll end up with two records in the processDef-table, both with draft and latest set to true, instead of 4 records were either draft or latest is true

## PR-Checklist

Please check the boxes in this list after submitting your PR:

- [x] You can merge this PR **right now** (if not, please prefix the title with "WIP: ")
- [x] I've tested **all** changes included in this PR.
- [x] I've also reviewed this PR myself before submitting (e.g. for scrambled letters, typos, etc.)
- [x] I've merged the `develop` branch into my branch before finishing this PR.
- [x] I've **not added any other changes** than the ones described above.
- [x] I've mentioned all **PRs, which relate to this one**
