### PR TITLE
Feature/feature/provide event key with end event message

### DIFF
--- a/package.json
+++ b/package.json
@@ -24,7 +24,7 @@
     "@essential-projects/messagebus_contracts": "^1.0.0",
     "@essential-projects/metadata": "^1.0.0",
     "@essential-projects/metadata_contracts": "^1.0.0",
-    "@process-engine/process_engine_contracts": "^1.0.0",
+    "@process-engine/process_engine_contracts": "1.0.0",
     "@essential-projects/routing_contracts": "^1.0.0",
     "@essential-projects/timing_contracts": "^1.0.0",
     "addict-ioc": "^2.2.8",

--- a/package.json
+++ b/package.json
@@ -3,7 +3,7 @@
   "publishConfig": {
     "registry": "https://www.npmjs.com"
   },
-  "version": "1.0.0",
+  "version": "1.1.0",
   "description": "the core components for the process engine",
   "license": "MIT",
   "main": "dist/commonjs/index.js",

--- a/package.json
+++ b/package.json
@@ -24,7 +24,7 @@
     "@essential-projects/messagebus_contracts": "^1.0.0",
     "@essential-projects/metadata": "^1.0.0",
     "@essential-projects/metadata_contracts": "^1.0.0",
-    "@process-engine/process_engine_contracts": "1.0.0",
+    "@process-engine/process_engine_contracts": "~1.0.0",
     "@essential-projects/routing_contracts": "^1.0.0",
     "@essential-projects/timing_contracts": "^1.0.0",
     "addict-ioc": "^2.2.8",


### PR DESCRIPTION
## What did you change?

- Provide the EndEvent's key with its messsage payload
- Send a notification to the process-instance messagebus channgel (This is a requirement for the consumer api. We have a function there, which allows to wait for a specific end event before resolving)

## How can others test the changes?

Run the tests in the consumer api.

## PR-Checklist

Please check the boxes in this list after submitting your PR:

- [x] You can merge this PR **right now** (if not, please prefix the title with "WIP: ")
- [x] I've tested **all** changes included in this PR.
- [x] I've also reviewed this PR myself before submitting (e.g. for scrambled letters, typos, etc.)
- [x] I've merged the `develop` branch into my branch before finishing this PR.
- [x] I've **not added any other changes** than the ones described above.
- [x] I've mentioned all **PRs, which relate to this one**
