### PR TITLE
✨ add createBpmnFromXml

### DIFF
--- a/package.json
+++ b/package.json
@@ -24,7 +24,7 @@
     "@essential-projects/messagebus_contracts": "^1.0.0",
     "@essential-projects/metadata": "^1.0.0",
     "@essential-projects/metadata_contracts": "^1.0.0",
-    "@process-engine/process_engine_contracts": "^1.0.0",
+    "@process-engine/process_engine_contracts": "^2.0.0",
     "@essential-projects/routing_contracts": "^1.0.0",
     "@essential-projects/timing_contracts": "^1.0.0",
     "addict-ioc": "^2.2.8",

--- a/src/bpmn_diagram.ts
+++ b/src/bpmn_diagram.ts
@@ -49,7 +49,9 @@ export class BpmnDiagram implements IBpmnDiagram {
 
       process.laneSets.forEach((laneSet) => {
 
-        lanes = lanes.concat(laneSet.lanes);
+        if (laneSet.lanes !== undefined) {
+          lanes = lanes.concat(laneSet.lanes);
+        }
       });
     }
 

--- a/src/process_engine_service.ts
+++ b/src/process_engine_service.ts
@@ -15,6 +15,7 @@ import { IFeature, IFeatureService } from '@essential-projects/feature_contracts
 import {IInvoker, InvocationType} from '@essential-projects/invocation_contracts';
 import { IDataMessage, IMessage, IMessageBusService, IMessageSubscription } from '@essential-projects/messagebus_contracts';
 import {
+  IBpmnDiagram,
   IErrorDeserializer,
   IImportFromFileOptions,
   INodeDefEntity,
@@ -192,8 +193,28 @@ export class ProcessEngineService implements IProcessEngineService {
     return userTask.getUserTaskData(context);
   }
 
-  public createBpmnFromXml(context: ExecutionContext, xml: string): Promise<IProcessDefEntity> {
-    throw new Error('Method not implemented.');
+  public async createBpmnFromXml(context: ExecutionContext, xml: string): Promise<IProcessDefEntity> {
+    const bpmnDiagram: IBpmnDiagram = await this.processDefEntityTypeService.parseBpmnXml(xml);
+    const processDef: IEntityType<IProcessDefEntity> = await this.datastoreService.getEntityType<IProcessDefEntity>('ProcessDef');
+    const processes: Array<any> = bpmnDiagram.getProcesses();
+
+    if (processes.length === 0) {
+      throw new Error('Model must contain a process');
+    }
+
+    await this.processDefEntityTypeService.importBpmnFromXml(context, {xml: xml});
+
+    const queryObject: IPrivateQueryOptions = {
+      query: {
+        attribute: 'key',
+        operator: '=',
+        value: processes[0].id,
+      },
+    };
+
+    const processDefEntity: IProcessDefEntity = await processDef.findOne(context, queryObject);
+
+    return await processDefEntity.toPojo(context);
   }
 
   private async _messageHandler(msg): Promise<void> {

--- a/src/process_engine_service.ts
+++ b/src/process_engine_service.ts
@@ -214,7 +214,7 @@ export class ProcessEngineService implements IProcessEngineService {
 
     const processDefEntity: IProcessDefEntity = await processDef.findOne(context, queryObject);
 
-    return await processDefEntity.toPojo(context);
+    return processDefEntity.toPojo(context);
   }
 
   private async _messageHandler(msg): Promise<void> {

--- a/src/process_engine_service.ts
+++ b/src/process_engine_service.ts
@@ -192,6 +192,10 @@ export class ProcessEngineService implements IProcessEngineService {
     return userTask.getUserTaskData(context);
   }
 
+  public createBpmnFromXml(context: ExecutionContext, xml: string): Promise<IProcessDefEntity> {
+    throw new Error('Method not implemented.');
+  }
+
   private async _messageHandler(msg): Promise<void> {
     debugInfo('we got a message: ', msg);
 


### PR DESCRIPTION
## What did you change?

I added a method that allows us to directly import BPMN diagrams.
This also fixes importing Models that have laneSets, but no lanes in them.

- The Processes imported through this method might not bexecutable!
- This should currently not be used to import models with more than one process, because of #54!

## How can others test the changes?

- Use this Version of process_engine and `^1.1.0` of process_engine_http in a process-engine
- `POST /processengine/create_bpmn_from_xml` with this body:
   ```
   {
     "xml": "YOUR_BPMN_XML_STRING"
   }
   ```
- See how the processes of that model are now in the database

## PR-Checklist

Please check the boxes in this list after submitting your PR:

- [x] You can merge this PR **right now** (if not, please prefix the title with "WIP: ")
- [x] I've tested **all** changes included in this PR.
- [x] I've also reviewed this PR myself before submitting (e.g. for scrambled letters, typos, etc.)
- [x] I've merged the `develop` branch into my branch before finishing this PR.
- [x] I've **not added any other changes** than the ones described above.
- [x] I've mentioned all **PRs, which relate to this one**
