### PR TITLE
:bug: Fix Duplicate Call to ScriptTask#save() 

### DIFF
--- a/src/entity_types/script_task.ts
+++ b/src/entity_types/script_task.ts
@@ -34,6 +34,7 @@ export class ScriptTaskEntity extends NodeInstanceEntity implements IScriptTaskE
     const processToken = this.processToken;
 
     const tokenData = processToken.data || {};
+    let continueEnd = true;
     let result;
 
     // call service
@@ -47,6 +48,7 @@ export class ScriptTaskEntity extends NodeInstanceEntity implements IScriptTaskE
         result = await scriptFunction.call(this, tokenData, context);
       } catch (err) {
         result = err;
+        continueEnd = false;
         this.error(context, err);
       }
 
@@ -62,6 +64,9 @@ export class ScriptTaskEntity extends NodeInstanceEntity implements IScriptTaskE
       processToken.data = tokenData;
     }
 
-    this.changeState(context, 'end', this);
+    if (continueEnd) {
+      this.changeState(context, 'end', this);
+    }
+
   }
 }


### PR DESCRIPTION
Having an interrupting boundary event will indirectly cause the script task to 'end' if an error is thrown.
The script task also 'end's on its own in a regualar fashion
Both 'end' calls will cause a duplicate call to save. This race condition causes the second save to fail.

Closes #56

## What did you change?

Adapt the ScriptTask behaivor to the behaivor of the ServiceTask

## How can others test the changes?

Please see #56 

## PR-Checklist

Please check the boxes in this list after submitting your PR:

- [x] You can merge this PR **right now** (if not, please prefix the title with "WIP: ")
- [x] I've tested **all** changes included in this PR.
- [x] I've also reviewed this PR myself before submitting (e.g. for scrambled letters, typos, etc.)
- [x] I've merged the `develop` branch into my branch before finishing this PR.
- [x] I've **not added any other changes** than the ones described above.
- [x] I've mentioned all **PRs, which relate to this one**
