### PR TITLE
✨ Improve token splitting

### DIFF
--- a/package.json
+++ b/package.json
@@ -24,7 +24,7 @@
     "@essential-projects/messagebus_contracts": "^1.0.0",
     "@essential-projects/metadata": "^1.0.0",
     "@essential-projects/metadata_contracts": "^1.0.0",
-    "@process-engine/process_engine_contracts": "^2.0.0",
+    "@process-engine/process_engine_contracts": "^3.0.0",
     "@essential-projects/routing_contracts": "^1.0.0",
     "@essential-projects/timing_contracts": "^1.0.0",
     "@essential-projects/foundation": "^1.0.0",

--- a/package.json
+++ b/package.json
@@ -27,6 +27,7 @@
     "@process-engine/process_engine_contracts": "^2.0.0",
     "@essential-projects/routing_contracts": "^1.0.0",
     "@essential-projects/timing_contracts": "^1.0.0",
+    "@essential-projects/foundation": "^1.0.0",
     "addict-ioc": "^2.2.8",
     "bluebird": "^3.4.7",
     "bpmn-moddle": "^0.14.0",

--- a/src/entity_type_services/node_instance.ts
+++ b/src/entity_type_services/node_instance.ts
@@ -418,9 +418,7 @@ export class NodeInstanceEntityTypeService implements INodeInstanceEntityTypeSer
           }
 
           if (splitToken && i > 0) {
-            currentToken = await processTokenEntityType.createEntity(internalContext);
-            currentToken.process = processToken.process;
-            currentToken.data = processToken.data;
+            currentToken = await processToken.clone();
 
             if (processDef.persist) {
               await currentToken.save(internalContext, { reloadAfterSave: false });

--- a/src/entity_types/boundary_event.ts
+++ b/src/entity_types/boundary_event.ts
@@ -46,7 +46,7 @@ export class BoundaryEventEntity extends EventEntity implements IBoundaryEventEn
 
   public async proceed(context: ExecutionContext, data: any, source: INodeInstanceEntity, applicationId: string, participant: string): Promise<void> {
     const parent: INodeInstanceEntity = this.attachedToInstance;
-    this.processToken = this.processToken.clone();
+    this.processToken = await this.processToken.clone();
     await parent.triggerBoundaryEvent(context, this, data);
   }
 }

--- a/src/entity_types/boundary_event.ts
+++ b/src/entity_types/boundary_event.ts
@@ -45,7 +45,8 @@ export class BoundaryEventEntity extends EventEntity implements IBoundaryEventEn
   }
 
   public async proceed(context: ExecutionContext, data: any, source: INodeInstanceEntity, applicationId: string, participant: string): Promise<void> {
-    const parent = this.attachedToInstance;
+    const parent: INodeInstanceEntity = this.attachedToInstance;
+    this.processToken = this.processToken.clone();
     await parent.triggerBoundaryEvent(context, this, data);
   }
 }

--- a/src/entity_types/node_instance.ts
+++ b/src/entity_types/node_instance.ts
@@ -461,7 +461,7 @@ export class NodeInstanceEntity extends Entity implements INodeInstanceEntity {
             this.cancel(context);
           } else {
 
-            if (this.processToken.data === undefined && this.processToken.data === null) {
+            if (this.processToken.data === undefined || this.processToken.data === null) {
               this.processToken.data = {};
             }
             this.processToken.data.current = data;
@@ -484,7 +484,7 @@ export class NodeInstanceEntity extends Entity implements INodeInstanceEntity {
             this.cancel(context);
           } else {
 
-            if (this.processToken.data === undefined && this.processToken.data === null) {
+            if (this.processToken.data === undefined || this.processToken.data === null) {
               this.processToken.data = {};
             }
             this.processToken.data.current = data;
@@ -524,7 +524,7 @@ export class NodeInstanceEntity extends Entity implements INodeInstanceEntity {
                 this.cancel(internalContext);
               } else {
 
-                if (this.processToken.data === undefined && this.processToken.data === null) {
+                if (this.processToken.data === undefined || this.processToken.data === null) {
                   this.processToken.data = {};
                 }
                 this.processToken.data.current = data;

--- a/src/entity_types/node_instance.ts
+++ b/src/entity_types/node_instance.ts
@@ -215,10 +215,6 @@ export class NodeInstanceEntity extends Entity implements INodeInstanceEntity {
 
     const processTokenEntityType = await (await this.getDatastoreService()).getEntityType('ProcessToken');
 
-    if (this.process.processDef.persist) {
-      await currentToken.save(internalContext, { reloadAfterSave: false });
-    }
-
     const boundaryNodeCreatePromises = [];
     for (let i = 0; i < this.process.processDef.nodeDefCollection.data.length; i++) {
       const boundary = <INodeDefEntity> this.process.processDef.nodeDefCollection.data[i];
@@ -494,9 +490,8 @@ export class NodeInstanceEntity extends Entity implements INodeInstanceEntity {
             this.processToken.data.current = data;
 
             if (this.nodeDef.processDef.persist) {
-              await newToken.save(internalContext, { reloadAfterSave: false });
+              await this.processToken.save(internalContext, { reloadAfterSave: false });
             }
-            this.processToken = newToken;
 
             await this._publishToApi(context, 'message', data);
             eventEntity.changeState(context, 'follow', this);

--- a/src/entity_types/process_token.ts
+++ b/src/entity_types/process_token.ts
@@ -1,5 +1,6 @@
 import {ExecutionContext, IEntity, IInheritedSchema, SchemaAttributeType} from '@essential-projects/core_contracts';
 import {Entity, EntityDependencyHelper, IEntityType, IPropertyBag} from '@essential-projects/data_model_contracts';
+import {runtime} from '@essential-projects/foundation';
 import {schemaAttribute} from '@essential-projects/metadata';
 import {IProcessEntity, IProcessTokenEntity} from '@process-engine/process_engine_contracts';
 
@@ -26,6 +27,10 @@ export class ProcessTokenEntity extends Entity implements IProcessTokenEntity {
     this.setProperty(this, 'data', value);
   }
 
+  protected get entityType(): IEntityType<IProcessTokenEntity> {
+    return <IEntityType<IProcessTokenEntity>> super.entityType;
+  }
+
   @schemaAttribute({ type: 'Process' })
   public get process(): IProcessEntity {
     return this.getProperty(this, 'process');
@@ -37,6 +42,17 @@ export class ProcessTokenEntity extends Entity implements IProcessTokenEntity {
 
   public getProcess(context: ExecutionContext): Promise<IProcessEntity> {
     return this.getPropertyLazy(this, 'process', context);
+  }
+
+  public async clone(): Promise<IProcessTokenEntity> {
+    const timestamp: number = Date.now();
+    const tokenClone: IProcessTokenEntity = await this.entityType.createEntity(this.context);
+
+    // TODO: Create new token for this process instead of referencing it
+    tokenClone.process = this.process;
+    tokenClone.data = runtime.cloneDeep(this.data);
+
+    return tokenClone;
   }
 
 }

--- a/src/entity_types/process_token.ts
+++ b/src/entity_types/process_token.ts
@@ -48,7 +48,7 @@ export class ProcessTokenEntity extends Entity implements IProcessTokenEntity {
     const timestamp: number = Date.now();
     const tokenClone: IProcessTokenEntity = await this.entityType.createEntity(this.context);
 
-    // TODO: Create new token for this process instead of referencing it
+    // TODO: Create new process instead of referencing it
     tokenClone.process = this.process;
     tokenClone.data = runtime.cloneDeep(this.data);
 


### PR DESCRIPTION
## What did you change?

This updates token splitting according to these rules:

- Wenn ein BoundaryEvent ausgelöst wird, erstellt er sich einen Klon des
  aktuellen Tokens
- An einen Parallel Split Gateway wird für jeden ausgehenden Flow ein Klon des
  aktuellen Tokens erstellt
- An einem Parallel Join Gateway wird ein neuer Token erstellt, dessen history
  sich aus den Histories aller Tokens zusammensetzt
- Freistehende Events ohne eingehenden Flow (Alle StartEvents und Intermediate
  Catching Events (siehe BPMN Spech 2.0 Seite 261)) Erstellen einen komplett
  neuen Token wenn sie ausgelöst werden

## How can others test the changes?

run diagrams with parallel gateways and boundary events, and see if the correct tokens follow the correct flows

## PR-Checklist

Please check the boxes in this list after submitting your PR:

- [x] You can merge this PR **right now** (if not, please prefix the title with "WIP: ")
- [x] I've tested **all** changes included in this PR.
- [x] I've also reviewed this PR myself before submitting (e.g. for scrambled letters, typos, etc.)
- [x] I've merged the `develop` branch into my branch before finishing this PR.
- [x] I've **not added any other changes** than the ones described above.
- [x] I've mentioned all **PRs, which relate to this one**
