### PR TITLE
Provide endEventkey with regular process.end notification

### DIFF
--- a/package.json
+++ b/package.json
@@ -25,7 +25,7 @@
     "@essential-projects/messagebus_contracts": "^1.0.0",
     "@essential-projects/metadata": "^1.0.0",
     "@essential-projects/metadata_contracts": "^1.0.0",
-    "@process-engine/process_engine_contracts": "feature~provide_end_event_key_with_process_end_message",
+    "@process-engine/process_engine_contracts": "^3.2.0",
     "@essential-projects/routing_contracts": "^1.0.0",
     "@essential-projects/timing_contracts": "^1.0.0",
     "@essential-projects/foundation": "^1.0.0",

--- a/package.json
+++ b/package.json
@@ -24,7 +24,7 @@
     "@essential-projects/messagebus_contracts": "^1.0.0",
     "@essential-projects/metadata": "^1.0.0",
     "@essential-projects/metadata_contracts": "^1.0.0",
-    "@process-engine/process_engine_contracts": "^3.0.0",
+    "@process-engine/process_engine_contracts": "feature~provide_end_event_key_with_process_end_message",
     "@essential-projects/routing_contracts": "^1.0.0",
     "@essential-projects/timing_contracts": "^1.0.0",
     "@essential-projects/foundation": "^1.0.0",

--- a/src/entity_types/end_event.ts
+++ b/src/entity_types/end_event.ts
@@ -46,8 +46,6 @@ export class EndEventEntity extends EventEntity implements IEndEventEntity {
         await this.messageBusService.publish(`/role/${flatRole}`, msg);
       }
     }
-    // Required for the consumer api: Inform subscribers that this end event has been reached.
-    await this.messageBusService.publish(`/processengine/process/${this.process.id}`, msg);
     this.changeState(context, 'end', this);
   }
 }

--- a/src/entity_types/node_instance.ts
+++ b/src/entity_types/node_instance.ts
@@ -651,7 +651,7 @@ export class NodeInstanceEntity extends Entity implements INodeInstanceEntity {
       }
     } else {
       const process = await this.getProcess(internalContext);
-      await process.end(context, processToken);
+      await process.end(context, processToken, this.key);
     }
   }
 

--- a/src/entity_types/process.ts
+++ b/src/entity_types/process.ts
@@ -231,7 +231,7 @@ export class ProcessEntity extends Entity implements IProcessEntity {
     startEvent.changeState(laneContext, 'start', this);
   }
 
-  public async end(context: ExecutionContext, processToken: any): Promise<void> {
+  public async end(context: ExecutionContext, processToken: any, endEventKey?: string): Promise<void> {
 
     // Todo: end active node instances
 
@@ -256,11 +256,11 @@ export class ProcessEntity extends Entity implements IProcessEntity {
       const msg = this.messageBusService.createEntityMessage(data, source, context);
       const channel = '/processengine/node/' + callerId;
       await this.messageBusService.publish(channel, msg);
-
     }
 
     const processEndMessageData: any = {
       event: 'end',
+      endEventKey: endEventKey,
       token: processToken.data.current,
     };
 


### PR DESCRIPTION
Closes #63 
Requires: https://github.com/process-engine/process_engine_contracts/pull/21

## What did you change?

Provide the key of a reached EndEvent through the regular messagebus channel, instead via a separate message.
See referenced issue for more details.

## How can others test the changes?

Easiest way to test this, is to use the integrationtests of the consumer api.

## PR-Checklist

Please check the boxes in this list after submitting your PR:

- [x] You can merge this PR **right now** (if not, please prefix the title with "WIP: ")
- [x] I've tested **all** changes included in this PR.
- [x] I've also reviewed this PR myself before submitting (e.g. for scrambled letters, typos, etc.)
- [x] I've merged the `develop` branch into my branch before finishing this PR.
- [x] I've **not added any other changes** than the ones described above.
- [x] I've mentioned all **PRs, which relate to this one**
