### PR TITLE
Add isExecutable Flag to ProcessDefEntity and remove all remaining "draft" and "latest" usages

### DIFF
--- a/package.json
+++ b/package.json
@@ -3,7 +3,7 @@
   "publishConfig": {
     "registry": "https://www.npmjs.com"
   },
-  "version": "1.4.1",
+  "version": "2.0.0",
   "description": "the core components for the process engine",
   "license": "MIT",
   "main": "dist/commonjs/index.js",
@@ -25,10 +25,10 @@
     "@essential-projects/messagebus_contracts": "^1.0.0",
     "@essential-projects/metadata": "^1.0.0",
     "@essential-projects/metadata_contracts": "^1.0.0",
-    "@process-engine/process_engine_contracts": "^3.2.0",
     "@essential-projects/routing_contracts": "^1.0.0",
     "@essential-projects/timing_contracts": "^1.0.0",
     "@essential-projects/foundation": "^1.0.0",
+    "@process-engine/process_engine_contracts": "4.0.0",
     "addict-ioc": "^2.2.8",
     "bluebird": "^3.4.7",
     "bpmn-moddle":"^0.14.0",

--- a/src/entity_type_services/process_def.ts
+++ b/src/entity_type_services/process_def.ts
@@ -6,7 +6,7 @@ import {
   IPublicGetOptions,
   IQueryClause,
 } from '@essential-projects/core_contracts';
-import { IDatastoreService, IEntityType } from '@essential-projects/data_model_contracts';
+import { IDatastoreService, IEntityCollection, IEntityType } from '@essential-projects/data_model_contracts';
 import { IInvoker } from '@essential-projects/invocation_contracts';
 import {
   IImportFromFileOptions, IImportFromXmlOptions, IParamImportFromFile,
@@ -18,6 +18,7 @@ import { BpmnDiagram } from '../bpmn_diagram';
 import * as BluebirdPromise from 'bluebird';
 import * as BpmnModdle from 'bpmn-moddle';
 
+// tslint:disable:cyclomatic-complexity
 export class ProcessDefEntityTypeService implements IProcessDefEntityTypeService {
 
   private _datastoreService: IDatastoreService = undefined;
@@ -45,19 +46,20 @@ export class ProcessDefEntityTypeService implements IProcessDefEntityTypeService
 
   public async importBpmnFromFile(context: ExecutionContext, params: IParamImportFromFile, options?: IImportFromFileOptions): Promise<any> {
 
-    const pathString = params && params.file ? params.file : null;
-    if (pathString) {
+    const path: string = params && params.file ? params.file : null;
+    if (path) {
 
-      const xmlString = await this.processRepository.getXmlFromFile(pathString);
-      const name = pathString.split('/').pop();
+      const xml: string = await this.processRepository.getXmlFromFile(path);
+      const name: string = path.split('/').pop();
       await this.importBpmnFromXml(
         context,
         {
-          xml: xmlString,
-          path: pathString,
+          xml: xml,
+          path: path,
           internalName: name,
         },
         options);
+
       return { result: true };
 
     }
@@ -80,42 +82,30 @@ export class ProcessDefEntityTypeService implements IProcessDefEntityTypeService
       return;
     }
 
-    const bpmnDiagram = await this.parseBpmnXml(xml);
-    const processDef = await this.datastoreService.getEntityType<IProcessDefEntity>('ProcessDef');
-    const processes = bpmnDiagram.getProcesses();
+    const bpmnDiagram: BpmnDiagram = await this.parseBpmnXml(xml);
+    const processDef: IEntityType<IProcessDefEntity> = await this.datastoreService.getEntityType<IProcessDefEntity>('ProcessDef');
+    const processes: any = bpmnDiagram.getProcesses();
 
-    for (let i = 0; i < processes.length; i++) {
-      const process = processes[i];
+    for (const process of processes) {
 
       // query with key
-      const queryObject: ICombinedQueryClause = {
-        operator: 'and',
-        queries: [
-          {
-            attribute: 'key',
-            operator: '=',
-            value: process.id,
-          },
-          {
-            attribute: 'draft',
-            operator: '=',
-            value: true,
-          },
-        ],
+      const queryParams: IPrivateQueryOptions = {
+        query: {
+          attribute: 'key',
+          operator: '=',
+          value: process.id,
+        },
       };
-      const queryParams: IPrivateQueryOptions = { query: queryObject };
-      const processDefColl = await processDef.query(context, queryParams);
+      const processDefColl: IEntityCollection<IProcessDefEntity> = await processDef.query(context, queryParams);
 
       let processDefEntity: IProcessDefEntity = processDefColl && processDefColl.length > 0 ? processDefColl.data[0] as IProcessDefEntity : null;
 
-      let canSave = false;
+      let canSave: boolean = false;
       if (!processDefEntity) {
-        const processDefData = {
+        const processDefData: any = {
           key: process.id,
           defId: bpmnDiagram.definitions.id,
           counter: 0,
-          draft: true,
-          latest: true,
         };
 
         processDefEntity = await processDef.createEntity(context, processDefData);
@@ -147,16 +137,16 @@ export class ProcessDefEntityTypeService implements IProcessDefEntityTypeService
 
   public parseBpmnXml(xml: string): Promise<BpmnDiagram> {
 
-    const moddle = BpmnModdle();
+    const moddle: BpmnModdle = BpmnModdle();
 
-    return <any> (new BluebirdPromise<BpmnDiagram>((resolve, reject) => {
+    return <any> (new BluebirdPromise<BpmnDiagram>((resolve: Function, reject: Function): void => {
 
-      moddle.fromXML(xml, (error, definitions) => {
+      moddle.fromXML(xml, (error: Error, definitions: any) => {
         if (error) {
           reject(error);
         } else {
 
-          const bpmnDiagram = new BpmnDiagram(definitions);
+          const bpmnDiagram: BpmnDiagram = new BpmnDiagram(definitions);
           resolve(bpmnDiagram);
         }
       });
@@ -179,10 +169,10 @@ export class ProcessDefEntityTypeService implements IProcessDefEntityTypeService
 
     let processDefEntity: IProcessDefEntity;
 
-    processDefEntity = await this._findLatest(context, processId, key, version);
+    processDefEntity = await this._find(context, processId, key, version);
 
     if (!processDefEntity) {
-      // no process def with flag latest is found, for backwards compability we only query with key
+      // Backwards compatibility
       processDefEntity = await this._findByKeyOnly(context, processId, key);
     }
 
@@ -191,44 +181,30 @@ export class ProcessDefEntityTypeService implements IProcessDefEntityTypeService
     }
   }
 
-  private async _findLatest(context: ExecutionContext, processId: string, key: string, version: string): Promise<IProcessDefEntity> {
+  private async _find(context: ExecutionContext, processId: string, key: string, version: string): Promise<IProcessDefEntity> {
 
-    let attributeName: string = 'key';
-    let attributeValue: string = key;
-
-    if (processId) {
-      attributeName = 'id';
-      attributeValue = processId;
-    }
-
-    const queryObjectLatestVersion: ICombinedQueryClause = {
+    const queryObject: ICombinedQueryClause = {
       operator: 'and',
       queries: [
         {
-          attribute: attributeName,
+          attribute: processId ? 'id' : 'key',
           operator: '=',
-          value: attributeValue,
+          value: processId || key,
         },
       ],
     };
 
     if (version) {
-      queryObjectLatestVersion.queries.push({
+      queryObject.queries.push({
         attribute: 'version',
         operator: '=',
         value: version,
-      });
-    } else {
-      queryObjectLatestVersion.queries.push({
-        attribute: 'latest',
-        operator: '=',
-        value: true,
       });
     }
 
     const processDef: IEntityType<IProcessDefEntity> = await this.datastoreService.getEntityType<IProcessDefEntity>('ProcessDef');
 
-    return processDef.findOne(context, { query: queryObjectLatestVersion });
+    return processDef.findOne(context, { query: queryObject });
   }
 
   private async _findByKeyOnly(context: ExecutionContext, processId: string, key: string): Promise<IProcessDefEntity> {
@@ -246,18 +222,16 @@ export class ProcessDefEntityTypeService implements IProcessDefEntityTypeService
                                          processDefinitionKey: string,
                                          version?: string,
                                          versionlessFallback: boolean = false): Promise<IProcessDefEntity> {
-    const processDefinitionEntityType: IEntityType<IProcessDefEntity> = await this.datastoreService.getEntityType<IProcessDefEntity>('ProcessDef');
-    const processDefinitionByKeyQuery: IQueryClause = {
-      attribute: 'key',
-      operator: '=',
-      value: processDefinitionKey,
-    };
-    const processDefinitionByKeyAndVersionQuery: ICombinedQueryClause = this.getQueryForVersion(processDefinitionByKeyQuery, version);
 
-    let result: IProcessDefEntity = await processDefinitionEntityType.findOne(context, {query: processDefinitionByKeyAndVersionQuery});
-    if ((result === undefined || result === null) && versionlessFallback) {
+    let result: IProcessDefEntity;
+
+    if (version) {
+      result = await this._getByAttributeAndVersion(context, 'key', processDefinitionKey, version);
+    }
+
+    if (!result && versionlessFallback) {
       // We didn't find any versionized processDefinition, but versionlessFallback is true, so try getting one without a version
-      result = await processDefinitionEntityType.findOne(context, {query: processDefinitionByKeyQuery});
+      result = await this._getByAttribute(context, 'key', processDefinitionKey);
     }
 
     return result;
@@ -267,45 +241,63 @@ export class ProcessDefEntityTypeService implements IProcessDefEntityTypeService
                                         processDefinitionId: string,
                                         version?: string,
                                         versionlessFallback: boolean = false): Promise<IProcessDefEntity> {
-    const processDefinitionEntityType: IEntityType<IProcessDefEntity> = await this.datastoreService.getEntityType<IProcessDefEntity>('ProcessDef');
-    const processDefinitionByIdQuery: IQueryClause = {
-      attribute: 'id',
-      operator: '=',
-      value: processDefinitionId,
-    };
-    const processDefinitionByIdAndVersionQuery: ICombinedQueryClause = this.getQueryForVersion(processDefinitionByIdQuery, version);
 
-    let result: IProcessDefEntity = await processDefinitionEntityType.findOne(context, {query: processDefinitionByIdAndVersionQuery});
-    if ((result === undefined || result === null) && versionlessFallback) {
+    let result: IProcessDefEntity;
+
+    if (version) {
+      result = await this._getByAttributeAndVersion(context, 'id', processDefinitionId, version);
+    }
+
+    if (!result && versionlessFallback) {
       // We didn't find any versionized processDefinition, but versionlessFallback is true, so try getting one without a version
-      result = await processDefinitionEntityType.findOne(context, {query: processDefinitionByIdQuery});
+      result = await this._getByAttribute(context, 'id', processDefinitionId);
     }
 
     return result;
-}
+  }
 
-  private getQueryForVersion(inputQuery: IQueryClause, version?: string): ICombinedQueryClause {
-    const versionQuery: ICombinedQueryClause = {
+  private async _getByAttributeAndVersion(
+      context: ExecutionContext,
+      attributeName: string,
+      attributeValue: any,
+      version: string,
+    ): Promise<IProcessDefEntity> {
+
+    const query: ICombinedQueryClause = {
       operator: 'and',
-      queries: [
-        Object.assign({}, inputQuery),
-      ],
+      queries: [{
+        attribute: attributeName,
+        operator: '=',
+        value: attributeValue,
+      }],
     };
 
-    if (version === undefined) {
-      versionQuery.queries.push({
-        attribute: 'latest',
-        operator: '=',
-        value: true,
-      });
-    } else {
-      versionQuery.queries.push({
+    if (version !== undefined) {
+      query.queries.push({
         attribute: 'version',
         operator: '=',
         value: version,
       });
     }
+    const processDefinitionEntityType: IEntityType<IProcessDefEntity> = await this.datastoreService.getEntityType<IProcessDefEntity>('ProcessDef');
+    const result: IProcessDefEntity = await processDefinitionEntityType.findOne(context, {query: query});
 
-    return versionQuery;
+    return result;
+  }
+
+  private async _getByAttribute(context: ExecutionContext, attributeName: string, attributeValue: any): Promise<IProcessDefEntity> {
+
+    const query: IPrivateQueryOptions = {
+      query: {
+        attribute: attributeName,
+        operator: '=',
+        value: attributeValue,
+      },
+    };
+
+    const processDefinitionEntityType: IEntityType<IProcessDefEntity> = await this.datastoreService.getEntityType<IProcessDefEntity>('ProcessDef');
+    const result: IProcessDefEntity = await processDefinitionEntityType.findOne(context, {query: query});
+
+    return result;
   }
 }


### PR DESCRIPTION
Closes #68 
Closes #69

## What did you change?

- Removed any and all remaining references pertaining to the "latest" and "draft" flags
  - They are no longer a part of the `ProcessDefEntity` and will therefore no longer be included in the database, when a migration or database reset is performed
  - All usages of these properties have been removed from the `ProcessDefEntityTypeService`
- Added the `isExecutable` Flag to the `ProcessDefEntity` and implemented the retrieval of this flag
- Fixed a ton of TSLint errors.

## How can others test the changes?

`Draft` and `latest` weren't used anywhere anymore and the `isExecutable` is only a descriptive flag that doesn't really do anything yet and is only required by the consumer API.
Therefore, these changes shouldn't really affect anything at all.

Even so, to keep older customer specific releases intact, this is treated as a breaking change.

## PR-Checklist

Please check the boxes in this list after submitting your PR:

- [x] You can merge this PR **right now** (if not, please prefix the title with "WIP: ")
- [x] I've tested **all** changes included in this PR.
- [x] I've also reviewed this PR myself before submitting (e.g. for scrambled letters, typos, etc.)
- [x] I've merged the `develop` branch into my branch before finishing this PR.
- [x] I've **not added any other changes** than the ones described above.
- [x] I've mentioned all **PRs, which relate to this one**
