### PR TITLE
✨ Check if Process Name Is Unique

### DIFF
--- a/package.json
+++ b/package.json
@@ -31,10 +31,10 @@
     "@essential-projects/foundation": "^1.0.0",
     "addict-ioc": "^2.2.8",
     "bluebird": "^3.4.7",
-    "bpmn-moddle":"^0.14.0",
+    "bpmn-moddle": "^0.14.0",
     "debug": "^2.6.1",
     "loggerhythm": "^3.0.3",
-    "moment":"^2.22.1",
+    "moment": "^2.22.1",
     "xml2js": "^0.4.19"
   },
   "devDependencies": {

--- a/src/entity_type_services/process_def.ts
+++ b/src/entity_type_services/process_def.ts
@@ -256,6 +256,25 @@ export class ProcessDefEntityTypeService implements IProcessDefEntityTypeService
     return result;
   }
 
+  public async getProcessDefinitionByName(context: ExecutionContext,
+    processDefinitionName: string,
+    version?: string,
+    versionlessFallback: boolean = false): Promise<IProcessDefEntity> {
+
+    if (!version) {
+      return this._getByAttribute(context, 'name', processDefinitionName);
+    }
+
+    let result: IProcessDefEntity = await this._getByAttributeAndVersion(context, 'name', processDefinitionName, version);
+
+    if (!result && versionlessFallback) {
+      // We didn't find any versionized processDefinition, but versionlessFallback is true, so try getting one without a version
+      result = await this._getByAttribute(context, 'name', processDefinitionName);
+    }
+
+    return result;
+  }
+
   private async _getByAttributeAndVersion(
       context: ExecutionContext,
       attributeName: string,

--- a/src/process_engine_service.ts
+++ b/src/process_engine_service.ts
@@ -202,6 +202,11 @@ export class ProcessEngineService implements IProcessEngineService {
       throw new Error('Model must contain a process');
     }
 
+    const existingProcessDef = await this.processDefEntityTypeService.getProcessDefinitionByName(context, processes[0].id);
+    if(existingProcessDef !== null){
+      return;
+    }
+
     await this.processDefEntityTypeService.importBpmnFromXml(context, {xml: xml});
 
     const queryObject: IPrivateQueryOptions = {


### PR DESCRIPTION
## What did you change?

The function `createBpmnFromXml` now checks before creating a process definition if there already is a process definition with the same name. In that case, the backend now returns a `409 Conflict Error` and the process definition will not be created. 

## How can others test the changes?

- Import a XML
- Import the same XML again

## PR-Checklist

Please check the boxes in this list after submitting your PR:

- [x] You can merge this PR **right now** (if not, please prefix the title with "WIP: ")
- [x] I've tested **all** changes included in this PR.
- [x] I've also reviewed this PR myself before submitting (e.g. for scrambled letters, typos, etc.)
- [x] I've merged the `develop` branch into my branch before finishing this PR.
- [x] I've **not added any other changes** than the ones described above.
- [ ] I've mentioned all **PRs, which relate to this one**
