### PR TITLE
✨ Add Select Own Process Definition Name

### DIFF
--- a/package.json
+++ b/package.json
@@ -31,10 +31,10 @@
     "@essential-projects/foundation": "^1.0.0",
     "addict-ioc": "^2.2.8",
     "bluebird": "^3.4.7",
-    "bpmn-moddle":"^0.14.0",
+    "bpmn-moddle": "^0.14.0",
     "debug": "^2.6.1",
     "loggerhythm": "^3.0.3",
-    "moment":"^2.22.1",
+    "moment": "^2.22.1",
     "xml2js": "^0.4.19"
   },
   "devDependencies": {

--- a/package.json
+++ b/package.json
@@ -25,7 +25,7 @@
     "@essential-projects/messagebus_contracts": "^1.0.0",
     "@essential-projects/metadata": "^1.0.0",
     "@essential-projects/metadata_contracts": "^1.0.0",
-    "@process-engine/process_engine_contracts": "5.1.0-ed515abb-b2",
+    "@process-engine/process_engine_contracts": "feature~add_select_own_name",
     "@essential-projects/routing_contracts": "^1.0.0",
     "@essential-projects/timing_contracts": "^1.0.0",
     "@essential-projects/foundation": "^1.0.0",

--- a/package.json
+++ b/package.json
@@ -25,7 +25,7 @@
     "@essential-projects/messagebus_contracts": "^1.0.0",
     "@essential-projects/metadata": "^1.0.0",
     "@essential-projects/metadata_contracts": "^1.0.0",
-    "@process-engine/process_engine_contracts": "^5.0.0",
+    "@process-engine/process_engine_contracts": "5.1.0-ed515abb-b2",
     "@essential-projects/routing_contracts": "^1.0.0",
     "@essential-projects/timing_contracts": "^1.0.0",
     "@essential-projects/foundation": "^1.0.0",

--- a/src/entity_type_services/process_def.ts
+++ b/src/entity_type_services/process_def.ts
@@ -90,8 +90,10 @@ export class ProcessDefEntityTypeService implements IProcessDefEntityTypeService
 
     for (const process of processes) {
       let processName: string = name;
-      if (processName === null) {
-        processName = process.id;
+      let processId: string = name;
+      if (name === undefined || name === null) {
+        processName = process.name;
+        processId = process.id;
       }
 
       // query with key
@@ -109,7 +111,7 @@ export class ProcessDefEntityTypeService implements IProcessDefEntityTypeService
       let canSave: boolean = false;
       if (!processDefEntity) {
         const processDefData: any = {
-          key: processName,
+          key: processId,
           defId: bpmnDiagram.definitions.id,
           counter: 0,
         };
@@ -127,7 +129,7 @@ export class ProcessDefEntityTypeService implements IProcessDefEntityTypeService
         continue;
       }
 
-      processDefEntity.name = name;
+      processDefEntity.name = processName;
       processDefEntity.xml = xml;
       processDefEntity.internalName = internalName;
       processDefEntity.path = pathString;

--- a/src/entity_type_services/process_def.ts
+++ b/src/entity_type_services/process_def.ts
@@ -89,12 +89,10 @@ export class ProcessDefEntityTypeService implements IProcessDefEntityTypeService
     const processes: any = bpmnDiagram.getProcesses();
 
     for (const process of processes) {
-      let processName: string = name;
-      let processId: string = name;
-      if (name === undefined || name === null) {
-        processName = process.name;
-        processId = process.id;
-      }
+      const nameIsInvalid: boolean = (name === undefined || name === null);
+
+      const processName: string = nameIsInvalid ? process.name : name;
+      const processId: string = nameIsInvalid ? process.id : name;
 
       // query with key
       const queryParams: IPrivateQueryOptions = {

--- a/src/entity_type_services/process_def.ts
+++ b/src/entity_type_services/process_def.ts
@@ -262,25 +262,6 @@ export class ProcessDefEntityTypeService implements IProcessDefEntityTypeService
     return result;
   }
 
-  public async getProcessDefinitionByName(context: ExecutionContext,
-                                          processDefinitionName: string,
-                                          version?: string,
-                                          versionlessFallback: boolean = false): Promise<IProcessDefEntity> {
-
-    if (!version) {
-      return this._getByAttribute(context, 'name', processDefinitionName);
-    }
-
-    let result: IProcessDefEntity = await this._getByAttributeAndVersion(context, 'name', processDefinitionName, version);
-
-    if (!result && versionlessFallback) {
-      // We didn't find any versionized processDefinition, but versionlessFallback is true, so try getting one without a version
-      result = await this._getByAttribute(context, 'name', processDefinitionName);
-    }
-
-    return result;
-  }
-
   private async _getByAttributeAndVersion(
       context: ExecutionContext,
       attributeName: string,

--- a/src/entity_type_services/process_def.ts
+++ b/src/entity_type_services/process_def.ts
@@ -72,13 +72,13 @@ export class ProcessDefEntityTypeService implements IProcessDefEntityTypeService
 
     const overwriteExisting: boolean = options && options.hasOwnProperty('overwriteExisting') ? options.overwriteExisting : true;
 
-    const name = params && params.name ? params.name : null;
-    const xml = params && params.xml ? params.xml : null;
-    const internalName = params && params.internalName ? params.internalName : null;
-    const pathString = params && params.path ? params.path : null;
-    const category = params && params.category ? params.category : null;
-    const module = params && params.module ? params.module : null;
-    const readonly = params && params.readonly ? params.readonly : null;
+    const name: string = params && params.name ? params.name : null;
+    const xml: string = params && params.xml ? params.xml : null;
+    const internalName: string = params && params.internalName ? params.internalName : null;
+    const pathString: string = params && params.path ? params.path : null;
+    const category: string = params && params.category ? params.category : null;
+    const module: string = params && params.module ? params.module : null;
+    const readonly: boolean = params && params.readonly ? params.readonly : null;
 
     if (!xml) {
       return;

--- a/src/entity_type_services/process_def.ts
+++ b/src/entity_type_services/process_def.ts
@@ -101,7 +101,7 @@ export class ProcessDefEntityTypeService implements IProcessDefEntityTypeService
         query: {
           attribute: 'key',
           operator: '=',
-          value: processName,
+          value: processId,
         },
       };
       const processDefColl: IEntityCollection<IProcessDefEntity> = await processDef.query(context, queryParams);

--- a/src/process_engine_service.ts
+++ b/src/process_engine_service.ts
@@ -202,14 +202,12 @@ export class ProcessEngineService implements IProcessEngineService {
       throw new Error('Model must contain a process');
     }
 
-    let diagramName: string = name;
-    let diagramKey: string = name;
-    if (name === null || name === undefined) {
-      diagramName = processes[0].name;
-      diagramKey = processes[0].id;
-    } else {
-      xml = xml.replace(`id="${processes[0].id}"`, `id="${name}"`)
-        .replace(`processRef="${processes[0].id}"`, `processRef="${name}"`);
+    const diagramName: string = (name === undefined) ? processes[0].name : name;
+    const diagramKey: string = (name === undefined) ? processes[0].id : name;
+
+    if (name !== undefined) {
+        xml = xml.replace(`id="${processes[0].id}"`, `id="${name}"`)
+         .replace(`processRef="${processes[0].id}"`, `processRef="${name}"`);
     }
 
     await this.processDefEntityTypeService.importBpmnFromXml(context, {name: diagramName, xml: xml});

--- a/src/process_engine_service.ts
+++ b/src/process_engine_service.ts
@@ -202,8 +202,9 @@ export class ProcessEngineService implements IProcessEngineService {
       throw new Error('Model must contain a process');
     }
 
-    const diagramName: string = (name === undefined) ? processes[0].name : name;
-    const diagramKey: string = (name === undefined) ? processes[0].id : name;
+    const nameIsInvalid: boolean = (name === undefined);
+    const diagramName: string = nameIsInvalid ? processes[0].name : name;
+    const diagramKey: string = nameIsInvalid ? processes[0].id : name;
 
     if (name !== undefined) {
         xml = xml.replace(`id="${processes[0].id}"`, `id="${name}"`)

--- a/src/process_engine_service.ts
+++ b/src/process_engine_service.ts
@@ -202,22 +202,22 @@ export class ProcessEngineService implements IProcessEngineService {
       throw new Error('Model must contain a process');
     }
 
-    let diagrammName: string = name;
-    let diagrammKey: string = name;
-    if (diagrammName === null || diagrammName === undefined) {
-      diagrammName = processes[0].name;
-      diagrammKey = processes[0].id;
+    let diagramName: string = name;
+    let diagramKey: string = name;
+    if (diagramName === null || diagramName === undefined) {
+      diagramName = processes[0].name;
+      diagramKey = processes[0].id;
     } else {
-      xml = xml.replace(`id="${processes[0].id}"`, `id="${diagrammName}"`);
-      xml = xml.replace(`processRef="${processes[0].id}"`, `processRef="${diagrammName}"`);
+      xml = xml.replace(`id="${processes[0].id}"`, `id="${diagramName}"`);
+      xml = xml.replace(`processRef="${processes[0].id}"`, `processRef="${diagramName}"`);
     }
 
-    await this.processDefEntityTypeService.importBpmnFromXml(context, {name: diagrammName, xml: xml});
+    await this.processDefEntityTypeService.importBpmnFromXml(context, {name: diagramName, xml: xml});
     const queryObject: IPrivateQueryOptions = {
       query: {
         attribute: 'key',
         operator: '=',
-        value: diagrammKey,
+        value: diagramKey,
       },
     };
 

--- a/src/process_engine_service.ts
+++ b/src/process_engine_service.ts
@@ -204,12 +204,12 @@ export class ProcessEngineService implements IProcessEngineService {
 
     let diagramName: string = name;
     let diagramKey: string = name;
-    if (diagramName === null || diagramName === undefined) {
+    if (name === null || name === undefined) {
       diagramName = processes[0].name;
       diagramKey = processes[0].id;
     } else {
-      xml = xml.replace(`id="${processes[0].id}"`, `id="${diagramName}"`);
-      xml = xml.replace(`processRef="${processes[0].id}"`, `processRef="${diagramName}"`);
+      xml = xml.replace(`id="${processes[0].id}"`, `id="${name}"`)
+        .replace(`processRef="${processes[0].id}"`, `processRef="${name}"`);
     }
 
     await this.processDefEntityTypeService.importBpmnFromXml(context, {name: diagramName, xml: xml});

--- a/src/process_engine_service.ts
+++ b/src/process_engine_service.ts
@@ -207,8 +207,9 @@ export class ProcessEngineService implements IProcessEngineService {
     const diagramKey: string = nameIsInvalid ? processes[0].id : name;
 
     if (name !== undefined) {
-        xml = xml.replace(`id="${processes[0].id}"`, `id="${name}"`)
-         .replace(`processRef="${processes[0].id}"`, `processRef="${name}"`);
+      xml = xml
+              .replace(`id="${processes[0].id}"`, `id="${name}"`)
+              .replace(`processRef="${processes[0].id}"`, `processRef="${name}"`);
     }
 
     await this.processDefEntityTypeService.importBpmnFromXml(context, {name: diagramName, xml: xml});

--- a/src/process_engine_service.ts
+++ b/src/process_engine_service.ts
@@ -193,7 +193,7 @@ export class ProcessEngineService implements IProcessEngineService {
     return userTask.getUserTaskData(context);
   }
 
-  public async createBpmnFromXml(context: ExecutionContext, name: string, xml: string): Promise<IProcessDefEntity> {
+  public async createBpmnFromXml(context: ExecutionContext, xml: string, name: string): Promise<IProcessDefEntity> {
     const bpmnDiagram: IBpmnDiagram = await this.processDefEntityTypeService.parseBpmnXml(xml);
     const processDef: IEntityType<IProcessDefEntity> = await this.datastoreService.getEntityType<IProcessDefEntity>('ProcessDef');
     const processes: Array<any> = bpmnDiagram.getProcesses();

--- a/src/process_engine_service.ts
+++ b/src/process_engine_service.ts
@@ -198,8 +198,10 @@ export class ProcessEngineService implements IProcessEngineService {
     const processDef: IEntityType<IProcessDefEntity> = await this.datastoreService.getEntityType<IProcessDefEntity>('ProcessDef');
     const processes: Array<any> = bpmnDiagram.getProcesses();
 
-    if (processes.length === 0) {
-      throw new Error('Model must contain a process');
+    const noProccessFound: boolean = (processes.length === 0);
+    if (noProccessFound) {
+      // TODO: We need an specific Error type here.
+      throw new Error('Model must contain a process.');
     }
 
     const nameIsInvalid: boolean = (name === undefined);
@@ -316,11 +318,11 @@ export class ProcessEngineService implements IProcessEngineService {
       // this is deprecated and should be replaced with the new datastore api
       if (this.messageBusService.isMaster) {
         this.messageBusService.subscribe(`/processengine`, this._messageHandler.bind(this));
-        debugInfo(`subscribed on Messagebus Master`);
+        debugInfo(`subscribed on Messagebus Master.`);
       }
 
     } catch (err) {
-      debugErr('subscription failed on Messagebus', err.message);
+      debugErr('subscription failed on Messagebus.', err.message);
       throw new Error(err.message);
     }
   }

--- a/src/process_engine_service.ts
+++ b/src/process_engine_service.ts
@@ -203,8 +203,10 @@ export class ProcessEngineService implements IProcessEngineService {
     }
 
     let diagrammName: string = name;
-    if (diagrammName === null) {
+    let diagrammKey: string = name;
+    if (diagrammName === null || diagrammName === undefined) {
       diagrammName = processes[0].name;
+      diagrammKey = processes[0].id;
     } else {
       xml = xml.replace(`id="${processes[0].id}"`, `id="${diagrammName}"`);
       xml = xml.replace(`processRef="${processes[0].id}"`, `processRef="${diagrammName}"`);
@@ -215,7 +217,7 @@ export class ProcessEngineService implements IProcessEngineService {
       query: {
         attribute: 'key',
         operator: '=',
-        value: diagrammName,
+        value: diagrammKey,
       },
     };
 

--- a/src/process_engine_service.ts
+++ b/src/process_engine_service.ts
@@ -218,13 +218,17 @@ export class ProcessEngineService implements IProcessEngineService {
     const diagramName: string = nameIsInvalid ? processes[0].name : name;
     const diagramKey: string = nameIsInvalid ? processes[0].id : name;
 
-    if (name !== undefined) {
-      xml = xml
-              .replace(`id="${processes[0].id}"`, `id="${name}"`)
-              .replace(`processRef="${processes[0].id}"`, `processRef="${name}"`);
+    if (nameIsInvalid) {
+      const xmlWithCorrectName: string = xml
+                                          .replace(`id="${processes[0].id}"`, `id="${name}"`)
+                                          .replace(`processRef="${processes[0].id}"`, `processRef="${name}"`);
+
+      await this.processDefEntityTypeService.importBpmnFromXml(context, {name: diagramName, xml: xmlWithCorrectName});
+    } else {
+      await this.processDefEntityTypeService.importBpmnFromXml(context, {name: diagramName, xml: xml});
     }
 
-    await this.processDefEntityTypeService.importBpmnFromXml(context, {name: diagramName, xml: xml});
+    //  TODO: Refactor into private method {{{ //
     const queryObject: IPrivateQueryOptions = {
       query: {
         attribute: 'key',
@@ -234,6 +238,7 @@ export class ProcessEngineService implements IProcessEngineService {
     };
 
     const processDefEntity: IProcessDefEntity = await processDef.findOne(context, queryObject);
+    //  }}} TODO: Refactor into private method //
 
     return processDefEntity.toPojo(context);
   }

--- a/src/process_engine_service.ts
+++ b/src/process_engine_service.ts
@@ -193,6 +193,16 @@ export class ProcessEngineService implements IProcessEngineService {
     return userTask.getUserTaskData(context);
   }
 
+  /*
+   * This creates an entry in the database for the XML of a BPMN diagram.
+   * Checks if the creation was successfull; returns a ProcessDefEntity on success.
+   *
+   * @param context Execution Context for the request.
+   * @param xml The XML body of the BPMN diagram.
+   * @param name The name for the diagram that will be saved.
+   *
+   * @return Promise<IProcessDefEntity> on success; Error if no processes given in XML.
+   */
   public async createBpmnFromXml(context: ExecutionContext, xml: string, name: string): Promise<IProcessDefEntity> {
     const bpmnDiagram: IBpmnDiagram = await this.processDefEntityTypeService.parseBpmnXml(xml);
     const processDef: IEntityType<IProcessDefEntity> = await this.datastoreService.getEntityType<IProcessDefEntity>('ProcessDef');


### PR DESCRIPTION
## What did you change?

The name of a process definition can now be set by user when importing.

Related to:

- https://github.com/process-engine/bpmn-studio/pull/294
- https://github.com/process-engine/process_engine_http/pull/11
- https://github.com/process-engine/process_engine_contracts/pull/27

Needs to be published first:
- https://github.com/process-engine/process_engine_contracts/pull/27

## How can others test the changes?

- Import a XML with a custom name

## PR-Checklist

Please check the boxes in this list after submitting your PR:

- [x] You can merge this PR **right now** (if not, please prefix the title with "WIP: ")
- [x] I've tested **all** changes included in this PR.
- [x] I've also reviewed this PR myself before submitting (e.g. for scrambled letters, typos, etc.)
- [x] I've merged the `develop` branch into my branch before finishing this PR.
- [x] I've **not added any other changes** than the ones described above.
- [x] I've mentioned all **PRs, which relate to this one**
