### PR TITLE
Add correlationId to ProcessInstanceEntity

### DIFF
--- a/package.json
+++ b/package.json
@@ -3,7 +3,7 @@
   "publishConfig": {
     "registry": "https://www.npmjs.com"
   },
-  "version": "3.0.1",
+  "version": "3.1.0",
   "description": "The ProcessEngine core package. ProcessEngine is a tool to bring BPMN diagrams to life in JS.",
   "license": "MIT",
   "main": "dist/commonjs/index.js",
@@ -25,7 +25,7 @@
     "@essential-projects/messagebus_contracts": "^1.0.0",
     "@essential-projects/metadata": "^1.0.0",
     "@essential-projects/metadata_contracts": "^1.0.0",
-    "@process-engine/process_engine_contracts": "^6.0.0",
+    "@process-engine/process_engine_contracts": "^6.1.0",
     "@essential-projects/routing_contracts": "^1.0.0",
     "@essential-projects/timing_contracts": "^1.0.0",
     "@essential-projects/foundation": "^1.0.0",

--- a/src/entity_types/process.ts
+++ b/src/entity_types/process.ts
@@ -141,6 +141,15 @@ export class ProcessEntity extends Entity implements IProcessEntity {
     this.setProperty(this, 'callerId', value);
   }
 
+  @schemaAttribute({ type: SchemaAttributeType.string })
+  public get correlationId(): string {
+    return this.getProperty(this, 'correlationId');
+  }
+
+  public set correlationId(value: string) {
+    this.setProperty(this, 'correlationId', value);
+  }
+
   public async initializeProcess(): Promise<void> {
     const internalContext: ExecutionContext = await this.iamService.createInternalContext('processengine_system');
     const processDef: IProcessDefEntity = await this.getProcessDef(internalContext);


### PR DESCRIPTION
## What did you change?

Adds the property `correlationId` to the process instance entity.

This requirement came during the implementation of the consumer api for the call activity.

## PR-Checklist

Please check the boxes in this list after submitting your PR:

- [x] You can merge this PR **right now** (if not, please prefix the title with "WIP: ")
- [x] I've tested **all** changes included in this PR.
- [x] I've also reviewed this PR myself before submitting (e.g. for scrambled letters, typos, etc.)
- [x] I've merged the `develop` branch into my branch before finishing this PR.
- [x] I've **not added any other changes** than the ones described above.
- [x] I've mentioned all **PRs, which relate to this one**
