### PR TITLE
Feature/pass correlation id to call activity

### DIFF
--- a/package.json
+++ b/package.json
@@ -3,7 +3,7 @@
   "publishConfig": {
     "registry": "https://www.npmjs.com"
   },
-  "version": "5.0.0",
+  "version": "5.1.0",
   "description": "The ProcessEngine core package. ProcessEngine is a tool to bring BPMN diagrams to life in JS.",
   "license": "MIT",
   "main": "dist/commonjs/index.js",

--- a/src/entity_types/subprocess_external.ts
+++ b/src/entity_types/subprocess_external.ts
@@ -117,9 +117,12 @@ export class SubprocessExternalEntity extends NodeInstanceEntity implements ISub
     const startCallbackType: StartCallbackType = StartCallbackType.CallbackOnEndEventReached;
 
     const payload: ProcessStartRequestPayload = {
-      // Setting this to undefined, will cause the Consumer API generate a Correlation ID (UUID).
-      correlation_id: undefined,
+      // If the process already has a correlation, use it for the call activity.
+      // Otherwise, set to undefined, so that the consumer api will create a new correlation (UUID).
+      correlation_id: this.process.correlationId || undefined,
       callerId: this.id,
+      // TODO - Question: Allow for parameters to be retrieved through extension properties, as it is done with service tasks?
+      // Using only the current token could be problematic, if you want to provide tokens from previous node instances.
       input_values: this.processToken.data.current || {},
     };
 


### PR DESCRIPTION
## What did you change?

If the current process instance is assigned to a correlation, the correlation ID will be passed to the call activities.

## How can others test the changes?

Run the tests.

## PR-Checklist

Please check the boxes in this list after submitting your PR:

- [x] You can merge this PR **right now** (if not, please prefix the title with "WIP: ")
- [x] I've tested **all** changes included in this PR.
- [x] I've also reviewed this PR myself before submitting (e.g. for scrambled letters, typos, etc.)
- [x] I've merged the `develop` branch into my branch before finishing this PR.
- [x] I've **not added any other changes** than the ones described above.
- [x] I've mentioned all **PRs, which relate to this one**
