### PR TITLE
Remove processEngineService.start convenience method

### DIFF
--- a/package.json
+++ b/package.json
@@ -3,7 +3,7 @@
   "publishConfig": {
     "registry": "https://www.npmjs.com"
   },
-  "version": "5.2.0",
+  "version": "6.0.0",
   "description": "The ProcessEngine core package. ProcessEngine is a tool to bring BPMN diagrams to life in JS.",
   "license": "MIT",
   "main": "dist/commonjs/index.js",

--- a/package.json
+++ b/package.json
@@ -29,7 +29,7 @@
     "@essential-projects/timing_contracts": "^2.0.0",
     "@essential-projects/foundation": "^1.0.0",
     "@process-engine/consumer_api_contracts": "^0.8.0",
-    "@process-engine/process_engine_contracts": "feature~remove_process_start_convenience_method",
+    "@process-engine/process_engine_contracts": "^8.0.0",
     "addict-ioc": "^2.2.8",
     "bluebird": "^3.4.7",
     "bpmn-moddle": "^0.14.0",

--- a/package.json
+++ b/package.json
@@ -3,7 +3,7 @@
   "publishConfig": {
     "registry": "https://www.npmjs.com"
   },
-  "version": "5.1.0",
+  "version": "5.2.0",
   "description": "The ProcessEngine core package. ProcessEngine is a tool to bring BPMN diagrams to life in JS.",
   "license": "MIT",
   "main": "dist/commonjs/index.js",
@@ -29,7 +29,7 @@
     "@essential-projects/timing_contracts": "^2.0.0",
     "@essential-projects/foundation": "^1.0.0",
     "@process-engine/consumer_api_contracts": "^0.8.0",
-    "@process-engine/process_engine_contracts": "^7.0.0",
+    "@process-engine/process_engine_contracts": "feature~remove_process_start_convenience_method",
     "addict-ioc": "^2.2.8",
     "bluebird": "^3.4.7",
     "bpmn-moddle": "^0.14.0",

--- a/src/process_engine_service.ts
+++ b/src/process_engine_service.ts
@@ -167,11 +167,6 @@ export class ProcessEngineService implements IProcessEngineService {
     this._continueOwnProcesses();
   }
 
-  public async start(context: ExecutionContext, params: IParamStart, options?: IPublicGetOptions): Promise<string> {
-    const processEntity: IEntityReference = await this.processDefEntityTypeService.start(context, params, options);
-    return processEntity.id;
-  }
-
   public async getUserTaskData(context: ExecutionContext, userTaskId: string): Promise<IUserTaskMessageData> {
     const nodeInstanceEntityTypeService: INodeInstanceEntityTypeService = await this._getNodeInstanceEntityTypeService();
     const userTaskEntityQueryOptions: IPrivateQueryOptions = {


### PR DESCRIPTION
Closes: #91 

## What did you change?

Removes the `start` method from the `ProcessEngineService`.

This method was an attempt to duplicate the `execute` method. However, since it completely circumvented messagebus subscription, processes that were started this way were never finished.

Since it is best-practice  to use one of the `execute` methods anyway, the `start` method was removed.

## How can others test the changes?

This should only be an internal change, so backend-wise all should run as before.
For the bpmn studio, this fixes the following issue: https://github.com/process-engine/process_engine/issues/91

## PR-Checklist

Please check the boxes in this list after submitting your PR:

- [x] You can merge this PR **right now** (if not, please prefix the title with "WIP: ")
- [x] I've tested **all** changes included in this PR.
- [x] I've also reviewed this PR myself before submitting (e.g. for scrambled letters, typos, etc.)
- [x] I've merged the `develop` branch into my branch before finishing this PR.
- [x] I've **not added any other changes** than the ones described above.
- [x] I've mentioned all **PRs, which relate to this one**
