### PR TITLE
Check if a node instance was ended with an error before calling 'end'

### DIFF
--- a/package.json
+++ b/package.json
@@ -3,7 +3,7 @@
   "publishConfig": {
     "registry": "https://www.npmjs.com"
   },
-  "version": "6.0.1",
+  "version": "6.0.2",
   "description": "The ProcessEngine core package. ProcessEngine is a tool to bring BPMN diagrams to life in JS.",
   "license": "MIT",
   "main": "dist/commonjs/index.js",

--- a/src/entity_types/node_instance.ts
+++ b/src/entity_types/node_instance.ts
@@ -352,8 +352,6 @@ export class NodeInstanceEntity extends Entity implements INodeInstanceEntity {
 
     logger.verbose(`node event, id ${this.id}, key ${this.key}, type ${this.type}, event ${eventType}`);
 
-    const internalContext: ExecutionContext = await this.iamService.createInternalContext('processengine_system');
-
     const map: Map<string, string> = new Map();
     map.set('error', 'bpmn:ErrorEventDefinition');
     map.set('cancel', 'bpmn:CancelEventDefinition');
@@ -400,7 +398,7 @@ export class NodeInstanceEntity extends Entity implements INodeInstanceEntity {
           await this._informProcessSubscribers(context, eventType, data);
         }
         await this._publishToApi(context, eventType, data);
-        await this.end(context, true);
+        await this.end(context, true, true);
       }
     }
 
@@ -614,7 +612,7 @@ export class NodeInstanceEntity extends Entity implements INodeInstanceEntity {
     }
   }
 
-  public async end(context: ExecutionContext, cancelFlow: boolean = false): Promise<void> {
+  public async end(context: ExecutionContext, cancelFlow: boolean = false, isEndedByError: boolean = false): Promise<void> {
 
     const isEndEvent: boolean = this.type === BpmnType.endEvent;
     const isTerminateEndEvent: boolean = this.nodeDef.eventType === 'bpmn:TerminateEventDefinition';
@@ -670,7 +668,7 @@ export class NodeInstanceEntity extends Entity implements INodeInstanceEntity {
       }
     } else if (isTerminateEndEvent) {
       await this.process.terminate(context, processToken, this.key);
-    } else {
+    } else if (isEndEvent || isEndedByError) {
       await this.process.end(context, processToken, this.key);
     }
   }
@@ -689,7 +687,6 @@ export class NodeInstanceEntity extends Entity implements INodeInstanceEntity {
     }
 
     await this._updateToken(internalContext);
-    const processToken: IProcessTokenEntity = this.processToken;
 
     // cancel subscriptions
     this.eventAggregatorSubscription.dispose();


### PR DESCRIPTION
## What did you change?

This fixes the handling of node instance errors, by adding an additional flag `isEndedWithError`.
If set to true, the signal is given to end the process. 
If not, execution will continue.

Note:
I know, this is quick, dirty and ugly. But since this code is pretty much obsolete anyway, I think it would be pointless to invest a lot of time in this.

## How can others test the changes?

Best way is to run the integration tests.

## PR-Checklist

Please check the boxes in this list after submitting your PR:

- [x] You can merge this PR **right now** (if not, please prefix the title with "WIP: ")
- [x] I've tested **all** changes included in this PR.
- [x] I've also reviewed this PR myself before submitting (e.g. for scrambled letters, typos, etc.)
- [x] I've merged the `develop` branch into my branch before finishing this PR.
- [x] I've **not added any other changes** than the ones described above.
- [x] I've mentioned all **PRs, which relate to this one**
