### PR TITLE
Feature/robustify flow node reference parsing

### DIFF
--- a/package.json
+++ b/package.json
@@ -3,7 +3,7 @@
   "publishConfig": {
     "registry": "https://www.npmjs.com"
   },
-  "version": "10.0.0",
+  "version": "10.0.1",
   "description": "The ProcessEngine core package. ProcessEngine is a tool to bring BPMN diagrams to life in JS.",
   "license": "MIT",
   "main": "dist/commonjs/index.js",

--- a/src/new_model/model/parser/process_lane_set_parser.ts
+++ b/src/new_model/model/parser/process_lane_set_parser.ts
@@ -6,33 +6,39 @@ import {
 
 export function parseProcessLaneSet(data: any): Model.Types.LaneSet {
 
-    const laneSetData: any = data[BpmnTags.Lane.LaneSet] || data[BpmnTags.LaneProperty.ChildLaneSet];
+  const laneSetData: any = data[BpmnTags.Lane.LaneSet] || data[BpmnTags.LaneProperty.ChildLaneSet];
 
-    if (!laneSetData) {
-      return undefined;
-    }
+  if (!laneSetData) {
+    return undefined;
+  }
 
-    // NOTE: See above, this can be an Object or an Array.
-    const lanesRaw: Array<any> = getModelPropertyAsArray(laneSetData, BpmnTags.Lane.Lane);
+  const lanesRaw: Array<any> = getModelPropertyAsArray(laneSetData, BpmnTags.Lane.Lane);
 
-    const laneSet: Model.Types.LaneSet = new Model.Types.LaneSet();
+  const laneSet: Model.Types.LaneSet = new Model.Types.LaneSet();
 
-    if (!lanesRaw) {
-      return laneSet;
-    }
-
-    for (const laneRaw of lanesRaw) {
-      const lane: Model.Types.Lane = createObjectWithCommonProperties(laneRaw, Model.Types.Lane);
-
-      lane.name = laneRaw.name;
-      lane.flowNodeReferences = laneRaw[BpmnTags.LaneProperty.FlowNodeRef];
-
-      if (laneRaw[BpmnTags.LaneProperty.ChildLaneSet]) {
-        lane.childLaneSet = parseProcessLaneSet(laneRaw);
-      }
-
-      laneSet.lanes.push(lane);
-    }
-
+  if (!lanesRaw) {
     return laneSet;
   }
+
+  for (const laneRaw of lanesRaw) {
+    const lane: Model.Types.Lane = createObjectWithCommonProperties(laneRaw, Model.Types.Lane);
+
+    lane.name = laneRaw.name;
+
+    const flowNodeReferenceTrimmer: any = (reference: string): string => {
+      return reference.trim();
+    };
+
+    const flowNodeReferences: Array<string> = laneRaw[BpmnTags.LaneProperty.FlowNodeRef];
+    const trimmedFlowNodeReferences: Array<string> = flowNodeReferences.map(flowNodeReferenceTrimmer);
+    lane.flowNodeReferences = trimmedFlowNodeReferences;
+
+    if (laneRaw[BpmnTags.LaneProperty.ChildLaneSet]) {
+      lane.childLaneSet = parseProcessLaneSet(laneRaw);
+    }
+
+    laneSet.lanes.push(lane);
+  }
+
+  return laneSet;
+}

--- a/src/new_model/model/type_factory.ts
+++ b/src/new_model/model/type_factory.ts
@@ -6,7 +6,17 @@ export function getModelPropertyAsArray(model: any, elementName: string): any {
     return undefined;
   }
 
-  return Array.isArray(model[elementName]) ? model[elementName] : [model[elementName]];
+  const modelElement: any = model[elementName];
+
+  if (Array.isArray(modelElement)) {
+    return modelElement;
+  }
+
+  if (typeof modelElement === 'string') {
+    return [modelElement.trim()];
+  }
+
+  return [modelElement];
 }
 
 export function createObjectWithCommonProperties<TTargetType extends Model.Base.BaseElement>(


### PR DESCRIPTION
Closes #118 

# What did you change?

Adds property name trimming to the lane set parser and the type factory.

## How can others test the changes?

Parse a process model with the object model parser and see if any `FlowNodeReferences` or `incoming`/`outgoing` properties contain any whitespaces or linebreaks.

## PR-Checklist

Please check the boxes in this list after submitting your PR:

- [x] You can merge this PR **right now** (if not, please prefix the title with "WIP: ")
- [x] I've tested **all** changes included in this PR.
- [x] I've also reviewed this PR myself before submitting (e.g. for scrambled letters, typos, etc.)
- [x] I've merged the `develop` branch into my branch before finishing this PR.
- [x] I've **not added any other changes** than the ones described above.
- [x] I've mentioned all **PRs, which relate to this one**
