### PR TITLE
Feature/provide process as xml

### DIFF
--- a/ioc_module.js
+++ b/ioc_module.js
@@ -38,10 +38,10 @@ function registerInContainer(container) {
     .dependencies('FlowNodeHandlerFactory', 'FlowNodeInstanceService', 'ProcessModelService', 'EventAggregator');
 
   container.register('FlowNodeInstanceService', FlowNodeInstanceService)
-    .dependencies('FlowNodeInstanceRepository', 'IamServiceNew');
+    .dependencies('FlowNodeInstanceRepository', 'IamService');
 
   container.register('ProcessModelService', ProcessModelService)
-    .dependencies('ProcessDefinitionRepository', 'IamServiceNew', 'BpmnModelParser');
+    .dependencies('ProcessDefinitionRepository', 'IamService', 'BpmnModelParser');
 
   container.register('TimerService', TimerService)
     .dependencies('EventAggregator', 'TimerRepository');

--- a/package.json
+++ b/package.json
@@ -19,7 +19,7 @@
     "@essential-projects/event_aggregator_contracts": "^3.0.0",
     "@essential-projects/iam_contracts": "^3.0.0",
     "@process-engine/consumer_api_contracts": "^0.12.1",
-    "@process-engine/process_engine_contracts": "feature~provide_process_as_xml",
+    "@process-engine/process_engine_contracts": "^15.0.0",
     "@types/clone": "^0.1.30",
     "addict-ioc": "^2.2.8",
     "bluebird": "^3.4.7",

--- a/package.json
+++ b/package.json
@@ -3,7 +3,7 @@
   "publishConfig": {
     "registry": "https://www.npmjs.com"
   },
-  "version": "13.0.0",
+  "version": "14.0.0",
   "description": "The ProcessEngine core package. ProcessEngine is a tool to bring BPMN diagrams to life in JS.",
   "license": "MIT",
   "main": "dist/commonjs/index.js",

--- a/package.json
+++ b/package.json
@@ -19,7 +19,7 @@
     "@essential-projects/event_aggregator_contracts": "^3.0.0",
     "@essential-projects/iam_contracts": "^3.0.0",
     "@process-engine/consumer_api_contracts": "^0.12.1",
-    "@process-engine/process_engine_contracts": "^14.1.0",
+    "@process-engine/process_engine_contracts": "feature~provide_process_as_xml",
     "@types/clone": "^0.1.30",
     "addict-ioc": "^2.2.8",
     "bluebird": "^3.4.7",

--- a/src/runtime/import_process_service.ts
+++ b/src/runtime/import_process_service.ts
@@ -60,10 +60,13 @@ export class ImportProcessService implements IImportProcessService {
       throw new Error('file does not exist');
     }
 
+    // filePath will be something like "/someFilePath/process_file_name.bpmn"
+    // The part we want to use with the import is "process_file_name".
     const name: string = filePath.split('/').pop();
+    const nameWithoutExtension: string = name.split('.')[0];
     const xml: string = await this._getXmlFromFile(filePath);
 
-    await this.importBpmnFromXml(context, xml, name, overwriteExisting);
+    await this.importBpmnFromXml(context, xml, nameWithoutExtension, overwriteExisting);
   }
 
   private async _getXmlFromFile(path: string): Promise<string> {

--- a/src/runtime/persistence/process_model_service.ts
+++ b/src/runtime/persistence/process_model_service.ts
@@ -96,7 +96,13 @@ export class ProcessModelService implements IProcessModelService {
 
   public async getProcessDefinitionAsXmlById(executionContextFacade: IExecutionContextFacade, processModelId: string): Promise<ProcessDefinitionRaw> {
 
-    return Promise.resolve({});
+    const definitionRaw: ProcessDefinitionRaw = await this.processDefinitionRepository.getProcessDefinitionByName(processModelId);
+
+    if (!definitionRaw) {
+      throw new NotFoundError(`Process definition with id ${processModelId} not found!`);
+    }
+
+    return definitionRaw;
   }
 
   private async _getProcessModelById(executionContextFacade: IExecutionContextFacade, processModelId: string): Promise<Model.Types.Process> {
@@ -147,10 +153,6 @@ export class ProcessModelService implements IProcessModelService {
 
     const identity: IIdentity = await executionContextFacade.getIdentity();
 
-    /*
-     * Ensure that this method always returns a copy and not a referece
-     * to the passed process model.
-     */
     const processModelCopy: Model.Types.Process = clone(processModel);
 
     if (!processModel.laneSet) {

--- a/src/runtime/persistence/process_model_service.ts
+++ b/src/runtime/persistence/process_model_service.ts
@@ -5,7 +5,7 @@ import {
   IProcessDefinitionRepository,
   IProcessModelService,
   Model,
-  ProcessDefinitionFromRepository,
+  ProcessDefinitionRaw,
 } from '@process-engine/process_engine_contracts';
 
 import {IIAMService, IIdentity} from '@essential-projects/iam_contracts';
@@ -94,6 +94,11 @@ export class ProcessModelService implements IProcessModelService {
     return filteredProcessModel;
   }
 
+  public async getProcessDefinitionAsXmlById(executionContextFacade: IExecutionContextFacade, processModelId: string): Promise<ProcessDefinitionRaw> {
+
+    return Promise.resolve({});
+  }
+
   private async _getProcessModelById(executionContextFacade: IExecutionContextFacade, processModelId: string): Promise<Model.Types.Process> {
 
     const processModelList: Array<Model.Types.Process> = await this._getProcessModelList();
@@ -124,14 +129,14 @@ export class ProcessModelService implements IProcessModelService {
 
   private async _getDefinitionList(): Promise<Array<Definitions>> {
 
-    const definitionsRaw: Array<ProcessDefinitionFromRepository> = await this.processDefinitionRepository.getProcessDefinitions();
+    const definitionsRaw: Array<ProcessDefinitionRaw> = await this.processDefinitionRepository.getProcessDefinitions();
 
-    const definitionsMapper: any = async(rawProcessModelData: ProcessDefinitionFromRepository): Promise<Definitions> => {
+    const definitionsMapper: any = async(rawProcessModelData: ProcessDefinitionRaw): Promise<Definitions> => {
       return this.bpmnModelParser.parseXmlToObjectModel(rawProcessModelData.xml);
     };
 
     const definitionsList: Array<Definitions> =
-      await BluebirdPromise.map<ProcessDefinitionFromRepository, Definitions>(definitionsRaw, definitionsMapper);
+      await BluebirdPromise.map<ProcessDefinitionRaw, Definitions>(definitionsRaw, definitionsMapper);
 
     return definitionsList;
   }


### PR DESCRIPTION
Closes #129 
Closes #130 

## What did you change?

- Rename `ProcessDefinitionFromRepository` to `ProcessDefinitionRaw`, since that object will now be used by the management api aswell
- Add methods for retrieving a processes' raw xml
  - `getProcessDefinitionAsXmlById` in the `ProcessModelService`
  - `getProcessDefinitionByName` in the `ProcessDefinitionRepository`
- Use the raw process name during import as a process definition name (without the `.bpmn` suffix)

## How can others test the changes?

- Use the import service for importing a process
- Use the updated persistence layer to retrieve a process definition in its raw xml format

## PR-Checklist

Please check the boxes in this list after submitting your PR:

- [x] You can merge this PR **right now** (if not, please prefix the title with "WIP: ")
- [x] I've tested **all** changes included in this PR.
- [x] I've also reviewed this PR myself before submitting (e.g. for scrambled letters, typos, etc.)
- [x] I've merged the `develop` branch into my branch before finishing this PR.
- [x] I've **not added any other changes** than the ones described above.
- [x] I've mentioned all **PRs, which relate to this one**
