### PR TITLE
Add error persistance

### DIFF
--- a/package.json
+++ b/package.json
@@ -19,7 +19,7 @@
     "@essential-projects/event_aggregator_contracts": "^3.0.0",
     "@essential-projects/iam_contracts": "^3.0.0",
     "@process-engine/consumer_api_contracts": "^0.14.0",
-    "@process-engine/process_engine_contracts": "^17.1.0",
+    "@process-engine/process_engine_contracts": "^18.0.0",
     "@types/clone": "^0.1.30",
     "addict-ioc": "^2.2.8",
     "bluebird": "^3.4.7",

--- a/src/runtime/persistence/flow_node_instance_service.ts
+++ b/src/runtime/persistence/flow_node_instance_service.ts
@@ -73,6 +73,16 @@ export class FlowNodeInstanceService implements IFlowNodeInstanceService {
     return this.flowNodeInstanceRepository.persistOnExit(token, flowNodeId, flowNodeInstanceId);
   }
 
+  public async persistOnError(executionContextFacade: IExecutionContextFacade,
+                              token: Runtime.Types.ProcessToken,
+                              flowNodeId: string,
+                              flowNodeInstanceId: string,
+                              error: Error,
+                            ): Promise<Runtime.Types.FlowNodeInstance> {
+
+    return this.flowNodeInstanceRepository.persistOnError(token, flowNodeId, flowNodeInstanceId, error);
+  }
+
   public async suspend(executionContextFacade: IExecutionContextFacade,
                        token: Runtime.Types.ProcessToken,
                        flowNodeInstanceId: string,


### PR DESCRIPTION
Depends on:
* https://github.com/process-engine/process_engine_contracts/pull/55
* https://github.com/process-engine/flow_node_instance.repository.sequelize/pull/7

## What did you change?

* the script task handler now uses a try/catch for script execution
* if an error occurs during script execution, the new `persistOnError`-method is used to persist the state as `error`
* `persistOnError` has been implemented in `FlowNodeInstanceService`

## How can others test the changes?

See https://github.com/process-engine/process_engine_meta/pull/118.

## PR-Checklist

Please check the boxes in this list after submitting your PR:

- [x] You can merge this PR **right now** (if not, please prefix the title with "WIP: ")
- [x] I've tested **all** changes included in this PR.
- [x] I've also reviewed this PR myself before submitting (e.g. for scrambled letters, typos, etc.)
- [x] I've merged the `develop` branch into my branch before finishing this PR.
- [x] I've **not added any other changes** than the ones described above.
- [x] I've mentioned all **PRs, which relate to this one**
