### PR TITLE
Add XML Validation on Deployment

### DIFF
--- a/src/runtime/persistence/process_model_service.ts
+++ b/src/runtime/persistence/process_model_service.ts
@@ -57,7 +57,7 @@ export class ProcessModelService implements IProcessModelService {
       });
 
       if (!hasDefinitionMatchingName) {
-        throw new BadRequestError(`The given xml does not contain a process definition with the name "${name}"`);
+        throw new BadRequestError(`The given XML does not contain a process definition with the name "${name}".`);
       }
 
     } catch (error) {
@@ -109,7 +109,7 @@ export class ProcessModelService implements IProcessModelService {
     const filteredProcessModel: Model.Types.Process = await this._filterInaccessibleProcessModelElements(executionContextFacade, processModel);
 
     if (!filteredProcessModel) {
-      throw new ForbiddenError('Access denied');
+      throw new ForbiddenError('Access denied.');
     }
 
     return filteredProcessModel;

--- a/src/runtime/persistence/process_model_service.ts
+++ b/src/runtime/persistence/process_model_service.ts
@@ -10,7 +10,7 @@ import {
 
 import {IIAMService, IIdentity} from '@essential-projects/iam_contracts';
 
-import {ForbiddenError, NotFoundError} from '@essential-projects/errors_ts';
+import {BadRequestError, ForbiddenError, NotFoundError, UnprocessableEntityError} from '@essential-projects/errors_ts';
 
 import * as BluebirdPromise from 'bluebird';
 import * as clone from 'clone';
@@ -45,6 +45,26 @@ export class ProcessModelService implements IProcessModelService {
     return this._bpmnModelParser;
   }
 
+  private async _validateXml(name: string, xml: string): Promise<void> {
+
+    try {
+      const parsedDefinitions: Definitions = await this.bpmnModelParser.parseXmlToObjectModel(xml);
+
+      const hasDefinitionMatchingName: boolean = parsedDefinitions
+        .processes
+        .some((definition: Model.Types.Process) => {
+          return definition.id === name;
+      });
+
+      if (!hasDefinitionMatchingName) {
+        throw new BadRequestError(`The given xml does not contain a process definition with the name "${name}"`);
+      }
+
+    } catch (error) {
+      throw new UnprocessableEntityError(`The XML for process ${name} could not be parsed.`);
+    }
+  }
+
   public async persistProcessDefinitions(executionContextFacade: IExecutionContextFacade,
                                          name: string,
                                          xml: string,
@@ -53,6 +73,7 @@ export class ProcessModelService implements IProcessModelService {
 
     const identity: IIdentity = executionContextFacade.getIdentity();
     await this.iamService.ensureHasClaim(identity, this._canWriteProcessModelClaim);
+    await this._validateXml(name, xml);
 
     return this.processDefinitionRepository.persistProcessDefinitions(name, xml, overwriteExisting);
   }

--- a/src/runtime/persistence/process_model_service.ts
+++ b/src/runtime/persistence/process_model_service.ts
@@ -61,7 +61,7 @@ export class ProcessModelService implements IProcessModelService {
       }
 
     } catch (error) {
-      throw new UnprocessableEntityError(`The XML for process ${name} could not be parsed.`);
+      throw new UnprocessableEntityError(`The XML for process "${name}" could not be parsed.`);
     }
   }
 


### PR DESCRIPTION
## What did you change?

* added an xml validation that 
   * throws `UnprocessableEntityError` if an error is thrown during xml parsing
   * throws `BadRequestError` if the parsed definitions don't contain a process whose `id` matches the name used to persist the xml definitions

## How can others test the changes?

See https://github.com/process-engine/skeleton/pull/71.

## PR-Checklist

Please check the boxes in this list after submitting your PR:

- [ ] You can merge this PR **right now** (if not, please prefix the title with "WIP: ")
- [x] I've tested **all** changes included in this PR.
- [x] I've also reviewed this PR myself before submitting (e.g. for scrambled letters, typos, etc.)
- [x] I've merged the `develop` branch into my branch before finishing this PR.
- [x] I've **not added any other changes** than the ones described above.
- [x] I've mentioned all **PRs, which relate to this one**
