### PR TITLE
[WIP]: Feature/reactivate terminate end event

### DIFF
--- a/ioc_module.js
+++ b/ioc_module.js
@@ -35,7 +35,7 @@ const ProcessModelFacadeFactory = require('./dist/commonjs/index').ProcessModelF
 function registerInContainer(container) {
 
   container.register('ExecuteProcessService', ExecuteProcessService)
-    .dependencies('FlowNodeHandlerFactory', 'FlowNodeInstanceService', 'ProcessModelService', 'EventAggregator');
+    .dependencies('FlowNodeHandlerFactory', 'FlowNodeInstanceService', 'EventAggregator');
 
   container.register('CorrelationService', CorrelationService)
     .dependencies('FlowNodeInstanceRepository', 'IamService');
@@ -79,7 +79,7 @@ function registerInContainer(container) {
     .dependencies('FlowNodeInstanceService');
 
   container.register('ParallelGatewayHandler', ParallelGatewayHandler)
-    .dependencies('FlowNodeHandlerFactory', 'FlowNodeInstanceService');
+    .dependencies('EventAggregator', 'FlowNodeHandlerFactory', 'FlowNodeInstanceService');
 
   container.register('ServiceTaskHandler', ServiceTaskHandler)
     .dependencies('container', 'FlowNodeInstanceService');

--- a/package.json
+++ b/package.json
@@ -20,7 +20,7 @@
     "@essential-projects/iam_contracts": "^3.1.0",
     "@essential-projects/timing_contracts": "^3.0.0",
     "@process-engine/consumer_api_contracts": "^0.15.0",
-    "@process-engine/process_engine_contracts": "^21.0.0",
+    "@process-engine/process_engine_contracts": "feature~reactivate_terminate_end_event",
     "@types/clone": "^0.1.30",
     "addict-ioc": "^2.2.8",
     "bluebird": "^3.4.7",

--- a/src/runtime/engine/execute_process_service.ts
+++ b/src/runtime/engine/execute_process_service.ts
@@ -209,11 +209,8 @@ export class ExecuteProcessService implements IExecuteProcessService {
 
     const flowNodeHandler: IFlowNodeHandler<Model.Base.FlowNode> = await this.flowNodeHandlerFactory.create(flowNode, processModelFacade);
 
-    const nextFlowNodeInfo: NextFlowNodeInfo = await flowNodeHandler.execute(flowNode,
-                                                                             processToken,
-                                                                             processTokenFacade,
-                                                                             processModelFacade,
-                                                                             executionContextFacade);
+    const nextFlowNodeInfo: NextFlowNodeInfo =
+      await flowNodeHandler.execute(flowNode, processToken, processTokenFacade, processModelFacade, executionContextFacade);
 
     if (this._processWasTerminated) {
       await this.flowNodeInstanceService.persistOnTerminate(executionContextFacade, processToken, flowNode.id, processToken.processInstanceId);

--- a/src/runtime/engine/handler/parallel_gateway_handler.ts
+++ b/src/runtime/engine/handler/parallel_gateway_handler.ts
@@ -65,12 +65,8 @@ export class ParallelGatewayHandler extends FlowNodeHandler<Model.Gateways.Paral
       const joinGateway: Model.Gateways.ParallelGateway = processModelFacade.getJoinGatewayFor(flowNode);
 
       // all parallel branches are only executed until the join gateway is reached
-      const parallelBranchExecutionPromises: Array<Promise<NextFlowNodeInfo>> = this._executeParallelBranches(outgoingSequenceFlows,
-                                                                                       joinGateway,
-                                                                                       token,
-                                                                                       processTokenFacade,
-                                                                                       processModelFacade,
-                                                                                       executionContextFacade);
+      const parallelBranchExecutionPromises: Array<Promise<NextFlowNodeInfo>> =
+        this._executeParallelBranches(outgoingSequenceFlows, joinGateway, token, processTokenFacade, processModelFacade, executionContextFacade);
 
       // After all parallel branches have been executed, each result is merged on the ProcessTokenFacade
       const nextFlowNodeInfos: Array<NextFlowNodeInfo> = await Promise.all(parallelBranchExecutionPromises);

--- a/src/runtime/persistence/flow_node_instance_service.ts
+++ b/src/runtime/persistence/flow_node_instance_service.ts
@@ -59,7 +59,7 @@ export class FlowNodeInstanceService implements IFlowNodeInstanceService {
                               token: Runtime.Types.ProcessToken,
                               flowNodeId: string,
                               flowNodeInstanceId: string,
-                            ): Promise<Runtime.Types.FlowNodeInstance> {
+                             ): Promise<Runtime.Types.FlowNodeInstance> {
 
     return this.flowNodeInstanceRepository.persistOnEnter(token, flowNodeId, flowNodeInstanceId);
   }
@@ -78,9 +78,18 @@ export class FlowNodeInstanceService implements IFlowNodeInstanceService {
                               flowNodeId: string,
                               flowNodeInstanceId: string,
                               error: Error,
-                            ): Promise<Runtime.Types.FlowNodeInstance> {
+                             ): Promise<Runtime.Types.FlowNodeInstance> {
 
     return this.flowNodeInstanceRepository.persistOnError(token, flowNodeId, flowNodeInstanceId, error);
+  }
+
+  public async persistOnTerminate(executionContextFacade: IExecutionContextFacade,
+                                  token: Runtime.Types.ProcessToken,
+                                  flowNodeId: string,
+                                  flowNodeInstanceId: string,
+                                 ): Promise<Runtime.Types.FlowNodeInstance> {
+
+    return this.flowNodeInstanceRepository.persistOnTerminate(token, flowNodeId, flowNodeInstanceId);
   }
 
   public async suspend(executionContextFacade: IExecutionContextFacade,


### PR DESCRIPTION
## What did you change?

Implement the `TerminateEndEvent`:
- The `EndEventHandler` will publish a new event, if a terminate end event was reached. This message is of the `TerminateEndEventReachedMessage` type
- `ParallelGatewayHandler` and `ExecuteProcessService` will listen for that message and if it was received, all flow node execution is stopped. Any FlowNodeInstance that may be active at the moment, will receive the `terminate` sate. No further FlowNodes will be run

## How can others test the changes?

Run the integrationtest for the TerminateEndEvent.

## PR-Checklist

Please check the boxes in this list after submitting your PR:

- [ ] You can merge this PR **right now** (if not, please prefix the title with "WIP: ")
- [ ] I've tested **all** changes included in this PR.
- [x] I've also reviewed this PR myself before submitting (e.g. for scrambled letters, typos, etc.)
- [x] I've merged the `develop` branch into my branch before finishing this PR.
- [x] I've **not added any other changes** than the ones described above.
- [x] I've mentioned all **PRs, which relate to this one**
